### PR TITLE
[FEAT] 공통 응답 클래스 작성

### DIFF
--- a/src/main/java/com/genius/herewe/util/response/CommonResponse.java
+++ b/src/main/java/com/genius/herewe/util/response/CommonResponse.java
@@ -1,0 +1,21 @@
+package com.genius.herewe.util.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommonResponse {
+    private HttpStatus code;
+    private int resultCode;
+
+    public CommonResponse(HttpStatus code) {
+        this.code = code;
+        this.resultCode = code.value();
+    }
+}

--- a/src/main/java/com/genius/herewe/util/response/ExceptionResponse.java
+++ b/src/main/java/com/genius/herewe/util/response/ExceptionResponse.java
@@ -1,0 +1,12 @@
+package com.genius.herewe.util.response;
+
+import org.springframework.http.HttpStatus;
+
+public class ExceptionResponse extends CommonResponse {
+    private String cause;
+
+    public ExceptionResponse(HttpStatus status, String cause) {
+        super(status);
+        this.cause = cause;
+    }
+}

--- a/src/main/java/com/genius/herewe/util/response/ListResponse.java
+++ b/src/main/java/com/genius/herewe/util/response/ListResponse.java
@@ -1,0 +1,19 @@
+package com.genius.herewe.util.response;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class ListResponse<T> extends CommonResponse {
+    private List<T> dataList;
+    private int count;
+
+    public ListResponse(HttpStatus status, List<T> dataList) {
+        super(status);
+        this.dataList = dataList;
+        this.count = dataList.size();
+    }
+}

--- a/src/main/java/com/genius/herewe/util/response/PagingResponse.java
+++ b/src/main/java/com/genius/herewe/util/response/PagingResponse.java
@@ -1,0 +1,15 @@
+package com.genius.herewe.util.response;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class PagingResponse<T> extends CommonResponse {
+    private Page<T> data;
+
+    public PagingResponse(HttpStatus status, Page<T> data) {
+        super(status);
+        this.data = data;
+    }
+}

--- a/src/main/java/com/genius/herewe/util/response/SingleResponse.java
+++ b/src/main/java/com/genius/herewe/util/response/SingleResponse.java
@@ -1,0 +1,16 @@
+package com.genius.herewe.util.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class SingleResponse<T> extends CommonResponse {
+    private T data;
+
+    public SingleResponse(HttpStatus status, T data) {
+        super(status);
+        this.data = data;
+    }
+}

--- a/src/main/java/com/genius/herewe/util/response/SlicingResponse.java
+++ b/src/main/java/com/genius/herewe/util/response/SlicingResponse.java
@@ -1,0 +1,15 @@
+package com.genius.herewe.util.response;
+
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class SlicingResponse<T> extends CommonResponse {
+    private Slice<T> data;
+
+    public SlicingResponse(HttpStatus status, Slice<T> data) {
+        super(status);
+        this.data = data;
+    }
+}


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/2-common-response` -> `main`

</br>

### 🛠️ 변경 사항
> API의 공통 응답 클래스와 비지니스 예외를 처리할 클래스를 작성합니다.

#### ✅ 작업 상세 내용
- [x] 모든 응답 클래스가 상속받을 공통 응답 클래스 `CommonResponse` 클래스 작성
- [x] SingleResponse: 단일 응답 클래스, ListResponse: 리스트 응답 클래스 작성
- [x] 페이징 관련 응답 클래스 PagingResponse, SlicingResponse 클래스 작성
- [x] 비지니스 예외 발생 시 사용할 응답 클래스 ExceptionResponse 클래스 작성 (실패 메시지 `cause` 데이터 추가)    

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/f941f98a-8200-4e95-8205-750403bdfe34)

</br>

### 📚 연관된 이슈
#2 

</br>

### 🤔 리뷰 요구사항(선택)

