### PR TITLE
[FIX] 아직 회원가입을 하지 않은 상태에서도 JWT 발급이 가능한 버그 픽스

### DIFF
--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 	NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다. 닉네임은 중복될 수 없습니다."),
 
+	UNAUTHORIZED_ISSUE(HttpStatus.UNAUTHORIZED, "회원가입이 되어 있지 않은 사용자의 경우 JWT를 발급할 수 없습니다."),
 	JWT_NOT_VALID(HttpStatus.UNAUTHORIZED, "JWT가 유효하지 않습니다."),
 	JWT_NOT_FOUND_IN_HEADER(HttpStatus.UNAUTHORIZED, "Header에서 JWT를 찾을 수 없습니다."),
 	JWT_NOT_FOUND_IN_COOKIE(HttpStatus.UNAUTHORIZED, "Cookie에서 JWT를 찾을 수 없습니다."),

--- a/src/main/java/com/genius/herewe/core/security/controller/AuthController.java
+++ b/src/main/java/com/genius/herewe/core/security/controller/AuthController.java
@@ -28,7 +28,6 @@ public class AuthController implements AuthApi {
 		@RequestBody AuthRequest authRequest) {
 
 		User user = userFacade.findUser(authRequest.userId());
-		jwtFacade.verifyIssueCondition(user);
 
 		jwtFacade.generateAccessToken(response, user);
 		jwtFacade.generateRefreshToken(response, user);

--- a/src/main/java/com/genius/herewe/core/security/controller/AuthController.java
+++ b/src/main/java/com/genius/herewe/core/security/controller/AuthController.java
@@ -28,6 +28,7 @@ public class AuthController implements AuthApi {
 		@RequestBody AuthRequest authRequest) {
 
 		User user = userFacade.findUser(authRequest.userId());
+		jwtFacade.verifyIssueCondition(user);
 
 		jwtFacade.generateAccessToken(response, user);
 		jwtFacade.generateRefreshToken(response, user);

--- a/src/main/java/com/genius/herewe/core/security/service/DefaultJwtFacade.java
+++ b/src/main/java/com/genius/herewe/core/security/service/DefaultJwtFacade.java
@@ -72,6 +72,8 @@ public class DefaultJwtFacade implements JwtFacade {
 
 	@Override
 	public String generateAccessToken(HttpServletResponse response, User user) {
+		verifyIssueCondition(user);
+
 		Long now = System.currentTimeMillis();
 		String token = Jwts.builder()
 			.setHeader(JwtUtil.createHeader())
@@ -92,6 +94,8 @@ public class DefaultJwtFacade implements JwtFacade {
 
 	@Override
 	public String generateRefreshToken(HttpServletResponse response, User user) {
+		verifyIssueCondition(user);
+
 		Long now = System.currentTimeMillis();
 		String refreshToken = Jwts.builder()
 			.setHeader(JwtUtil.createHeader())

--- a/src/main/java/com/genius/herewe/core/security/service/DefaultJwtFacade.java
+++ b/src/main/java/com/genius/herewe/core/security/service/DefaultJwtFacade.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.genius.herewe.core.global.exception.BusinessException;
 import com.genius.herewe.core.security.constants.JwtStatus;
 import com.genius.herewe.core.security.util.JwtUtil;
+import com.genius.herewe.core.user.domain.Role;
 import com.genius.herewe.core.user.domain.User;
 import com.genius.herewe.core.user.service.UserService;
 
@@ -60,6 +61,13 @@ public class DefaultJwtFacade implements JwtFacade {
 		this.REFRESH_SECRET_KEY = JwtUtil.getSigningKey(REFRESH_SECRET_KEY);
 		this.ACCESS_EXPIRATION = ACCESS_EXPIRATION;
 		this.REFRESH_EXPIRATION = REFRESH_EXPIRATION;
+	}
+
+	@Override
+	public void verifyIssueCondition(User user) {
+		if (user.getRole() == Role.NOT_REGISTERED) {
+			throw new BusinessException(UNAUTHORIZED_ISSUE);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/genius/herewe/core/security/service/JwtFacade.java
+++ b/src/main/java/com/genius/herewe/core/security/service/JwtFacade.java
@@ -9,6 +9,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface JwtFacade {
+	void verifyIssueCondition(User user);
+
 	String generateAccessToken(HttpServletResponse response, User user);
 
 	String generateRefreshToken(HttpServletResponse response, User user);

--- a/src/test/java/com/genius/herewe/core/security/service/JwtFacadeTest.java
+++ b/src/test/java/com/genius/herewe/core/security/service/JwtFacadeTest.java
@@ -58,8 +58,8 @@ class JwtFacadeTest {
 	}
 
 	@Nested
-	@DisplayName("토큰 생성 가능 조건 검사 시")
-	class Context_validate_issue_condition {
+	@DisplayName("access-token 생성 시")
+	class Context_create_access_token {
 		@Nested
 		@DisplayName("사용자의 ROLE 확인 시")
 		class Describe_check_user_role {
@@ -87,11 +87,6 @@ class JwtFacadeTest {
 					.isThrownBy(() -> jwtFacade.verifyIssueCondition(user));
 			}
 		}
-	}
-
-	@Nested
-	@DisplayName("access-token 생성 시")
-	class Context_create_access_token {
 
 		@Nested
 		@DisplayName("사용자 정보를 전달하면")
@@ -116,6 +111,34 @@ class JwtFacadeTest {
 	@Nested
 	@DisplayName("refresh-token 생성 시")
 	class Context_create_refresh_token {
+		@Nested
+		@DisplayName("사용자의 ROLE 확인 시")
+		class Describe_check_user_role {
+			@Test
+			@DisplayName("NOT_REGISTERED라면 UNAUTHORIZED_ISSUE 예외가 발생해야 한다.")
+			public void it_throws_UNAUTHORIZED_ISSUE_exception_when_NOT_REGISTERED() {
+				//given
+				User notRegistered = UserFixture.createByRole(Role.NOT_REGISTERED);
+
+				//when & then
+				assertThatThrownBy(() -> jwtFacade.verifyIssueCondition(notRegistered))
+					.isInstanceOf(BusinessException.class)
+					.hasMessageContaining(UNAUTHORIZED_ISSUE.getMessage());
+			}
+
+			@ParameterizedTest
+			@DisplayName("USER 또는 ADMIN인 경우 예외가 발생하지 않는다.")
+			@EnumSource(names = {"USER", "ADMIN"})
+			public void it_does_not_throw_exception(Role role) {
+				//given
+				User user = UserFixture.createByRole(role);
+
+				//when & then
+				assertThatNoException()
+					.isThrownBy(() -> jwtFacade.verifyIssueCondition(user));
+			}
+		}
+		
 		@Nested
 		@DisplayName("사용자 정보를 전달하면")
 		class Describe_pass_user_info {

--- a/src/test/java/com/genius/herewe/core/security/service/JwtFacadeTest.java
+++ b/src/test/java/com/genius/herewe/core/security/service/JwtFacadeTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,6 +19,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 
 import com.genius.herewe.core.global.exception.BusinessException;
 import com.genius.herewe.core.security.constants.JwtStatus;
+import com.genius.herewe.core.user.domain.Role;
 import com.genius.herewe.core.user.domain.User;
 import com.genius.herewe.core.user.fixture.UserFixture;
 import com.genius.herewe.core.user.service.UserService;
@@ -52,6 +55,38 @@ class JwtFacadeTest {
 			TEST_ISSUER, TEST_ACCESS_SECRET, TEST_REFRESH_SECRET,
 			TEST_ACCESS_EXPIRATION, TEST_REFRESH_EXPIRATION
 		);
+	}
+
+	@Nested
+	@DisplayName("토큰 생성 가능 조건 검사 시")
+	class Context_validate_issue_condition {
+		@Nested
+		@DisplayName("사용자의 ROLE 확인 시")
+		class Describe_check_user_role {
+			@Test
+			@DisplayName("NOT_REGISTERED라면 UNAUTHORIZED_ISSUE 예외가 발생해야 한다.")
+			public void it_throws_UNAUTHORIZED_ISSUE_exception_when_NOT_REGISTERED() {
+				//given
+				User notRegistered = UserFixture.createByRole(Role.NOT_REGISTERED);
+
+				//when & then
+				assertThatThrownBy(() -> jwtFacade.verifyIssueCondition(notRegistered))
+					.isInstanceOf(BusinessException.class)
+					.hasMessageContaining(UNAUTHORIZED_ISSUE.getMessage());
+			}
+
+			@ParameterizedTest
+			@DisplayName("USER 또는 ADMIN인 경우 예외가 발생하지 않는다.")
+			@EnumSource(names = {"USER", "ADMIN"})
+			public void it_does_not_throw_exception(Role role) {
+				//given
+				User user = UserFixture.createByRole(role);
+
+				//when & then
+				assertThatNoException()
+					.isThrownBy(() -> jwtFacade.verifyIssueCondition(user));
+			}
+		}
 	}
 
 	@Nested


### PR DESCRIPTION
### PR 타입
□ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`fix/26-jwt-issue-condition` -> `main`

</br>

### 🛠️ 변경 사항
사용자가 소셜로그인 이후, 아직 NOT_REGISTERED 상태에서 JWT를 발급할 수 있는 버그 픽스

#### ✅ 작업 상세 내용
-[x] JwtFacade에 발급 조건을 확인하는 verifyIssueCondition 메서드 추가
-[x] AuthController에서 해당 메서드 호출
-[x] 테스트 코드 작성

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/9f1a5c86-4b61-43c7-9a51-a2807038cdfe)


</br>

### 📚 연관된 이슈
#26

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
