### PR TITLE
[FEAT] 날짜 공통 포매팅 설정

### DIFF
--- a/src/main/java/com/genius/herewe/core/global/config/JacksonConfig.java
+++ b/src/main/java/com/genius/herewe/core/global/config/JacksonConfig.java
@@ -1,0 +1,33 @@
+package com.genius.herewe.core.global.config;
+
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
+@Configuration
+public class JacksonConfig {
+	private static final String dateFormat = "yyyy.MM.dd";
+	private static final String dateTimeFormat = "yyyy.MM.dd HH:mm:ss";
+
+	@Bean
+	public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
+		return builder -> {
+			// LocalDate 직렬화 포맷 설정 (Java 객체 -> JSON)
+			builder.serializers(new LocalDateSerializer(DateTimeFormatter.ofPattern(dateFormat)));
+			// LocalDate 역직렬화 포맷 설정 (JSON -> Java 객체)
+			builder.deserializers(new LocalDateDeserializer(DateTimeFormatter.ofPattern(dateFormat)));
+
+			// LocalDateTime 직렬화 포맷 설정 (Java 객체 -> JSON)
+			builder.serializers(new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(dateTimeFormat)));
+			// LocalDateTime 역직렬화 포맷 설정 (JSON -> Java 객체)
+			builder.deserializers(new LocalDateTimeDeserializer(DateTimeFormatter.ofPattern(dateTimeFormat)));
+		};
+	}
+}


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/29-date-formatting` -> `main`

</br>

### 🛠️ 변경 사항
#### 📋 어떤 기능인가요?
> LocalDateTime, LocalDate 필드의 값을 응답으로 전달할 때, 특정 포맷으로 전달하도록 공통 포매팅을 적용합니다.
> 기존: 2025-02-28 01:42:36.450 (LocalDateTime)
> 변경: 2025.02.28 01:42:36
> JacksonConfig 사용 예정

#### ✅ 작업 상세 내용
- [x] JacksonConfig를 통해 LocalDateTime, LocalDate를 `yyyy.MM.dd HH:mm:ss` 형태로 변환하도록 설정

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/7375818f-975c-465c-ab3c-8e46017a451a)


</br>

### 📚 연관된 이슈
#29

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
