### PR TITLE
[FEAT] 크루원 초대/가입 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,12 @@ dependencies {
     //AWS
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.0'
 
+    //thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    
+    //JavaMailSender
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
     //Websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 

--- a/src/main/java/com/genius/herewe/business/crew/controller/CrewApi.java
+++ b/src/main/java/com/genius/herewe/business/crew/controller/CrewApi.java
@@ -10,6 +10,8 @@ import com.genius.herewe.business.crew.dto.CrewMemberResponse;
 import com.genius.herewe.business.crew.dto.CrewModifyRequest;
 import com.genius.herewe.business.crew.dto.CrewPreviewResponse;
 import com.genius.herewe.business.crew.dto.CrewResponse;
+import com.genius.herewe.business.invitation.dto.InvitationRequest;
+import com.genius.herewe.core.global.response.CommonResponse;
 import com.genius.herewe.core.global.response.ExceptionResponse;
 import com.genius.herewe.core.global.response.PagingResponse;
 import com.genius.herewe.core.global.response.SingleResponse;
@@ -25,6 +27,17 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 
 public interface CrewApi {
+	@Operation(summary = "내가 참여한 크루 리스트 조회", description = "참여한 크루에 대해 pagination 형식으로 조회")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "참여한 크루의 정보 정상적으로 조회"
+		)
+	})
+	PagingResponse<CrewPreviewResponse> inquiryMyCrews(
+		@HereWeUser User user,
+		@PageableDefault(size = 10, page = 0) Pageable pageable);
+
 	@Operation(summary = "크루 정보 조회", description = "크루 ID, 이름, 리더 이름, 역할, 소개글, 참여인원 정보 반환")
 	@ApiResponses({
 		@ApiResponse(
@@ -172,5 +185,151 @@ public interface CrewApi {
 		@HereWeUser User user,
 		@PathVariable Long crewId,
 		@RequestBody CrewModifyRequest crewModifyRequest);
+
+	@Operation(summary = "크루 초대", description = "특정 사용자에게 크루 초대 요청 (초대 링크가 담긴 메일 전송)")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "크루 초대 요청 완료"
+		),
+		@ApiResponse(
+			responseCode = "400",
+			description = "초대 대상(사용자)이 이미 참여한 크루일 때",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "초대 대상(사용자)이 이미 참여한 크루일 때",
+						value = """
+							{
+								"resultCode": "400",
+								"code": "ALREADY_JOINED_CREW",
+								"message": "이미 참여한 크루입니다."
+							}
+							"""
+					)
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = """
+				1. nickname을 통해 해당 사용자를 찾지 못했을 때
+				2. crewId를 통해 해당 크루를 찾지 못했을 때
+				""",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "nickname을 통해 해당 사용자를 찾지 못했을 때",
+						value = """
+							{
+								"resultCode": "404",
+								"code": "MEMBER_NOT_FOUND",
+								"message": "사용자를 찾을 수 없습니다."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "crewId를 통해 해당 크루를 찾지 못했을 때",
+						value = """
+							{
+								"resultCode": "404",
+								"code": "CREW_NOT_FOUND",
+								"message": "해당 CREW를 찾을 수 없습니다."
+							}
+							"""
+					)
+				}
+			)
+		)
+	})
+	CommonResponse inviteCrew(
+		@Valid @RequestBody InvitationRequest invitationRequest);
+
+	@Operation(summary = "크루 참여 요청", description = "메일로 발송된 초대 토큰을 통해 크루에 가입 요청")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "해당 크루에 가입 완료"
+		),
+		@ApiResponse(
+			responseCode = "400",
+			description = """
+				1. 초대 토큰의 유효기간이 만료되었을 때
+				2. 초대 대상(사용자)이 이미 참여한 크루일 때
+				""",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "초대 토큰의 유효기간이 만료되었을 때",
+						value = """
+							{
+								"resultCode": "400",
+								"code": "INVITATION_EXPIRED",
+								"message": "크루 초대가 만료되었습니다."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "초대 대상(사용자)이 이미 참여한 크루일 때",
+						value = """
+							{
+								"resultCode": "400",
+								"code": "ALREADY_JOINED_CREW",
+								"message": "이미 참여한 크루입니다."
+							}
+							"""
+					)
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = """
+				1. 토큰을 통해 초대 정보를 찾지 못했을 때
+				2. 사용자 정보를 찾지 못했을 때
+				3. 크루 정보를 찾지 못했을 때
+				""",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "토큰을 통해 초대 정보를 찾지 못했을 때",
+						value = """
+							{
+								"resultCode": "404",
+								"code": "INVITATION_NOT_FOUND",
+								"message": "크루 초대 정보를 찾을 수 없습니다. 초대 정보를 다시 확인해주세요."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "사용자 정보를 찾지 못했을 때",
+						value = """
+							{
+								"resultCode": "404",
+								"code": "MEMBER_NOT_FOUND",
+								"message": "사용자를 찾을 수 없습니다."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "크루 정보를 찾지 못했을 때",
+						value = """
+							{
+								"resultCode": "404",
+								"code": "CREW_NOT_FOUND",
+								"message": "해당 CREW를 찾을 수 없습니다."
+							}
+							"""
+					)
+				}
+			)
+		)
+	})
+	CommonResponse joinCrew(@PathVariable String inviteToken);
+
 }
 

--- a/src/main/java/com/genius/herewe/business/crew/controller/CrewApi.java
+++ b/src/main/java/com/genius/herewe/business/crew/controller/CrewApi.java
@@ -10,7 +10,6 @@ import com.genius.herewe.business.crew.dto.CrewMemberResponse;
 import com.genius.herewe.business.crew.dto.CrewModifyRequest;
 import com.genius.herewe.business.crew.dto.CrewPreviewResponse;
 import com.genius.herewe.business.crew.dto.CrewResponse;
-import com.genius.herewe.core.global.response.CommonResponse;
 import com.genius.herewe.core.global.response.ExceptionResponse;
 import com.genius.herewe.core.global.response.PagingResponse;
 import com.genius.herewe.core.global.response.SingleResponse;
@@ -173,14 +172,5 @@ public interface CrewApi {
 		@HereWeUser User user,
 		@PathVariable Long crewId,
 		@RequestBody CrewModifyRequest crewModifyRequest);
-
-	@Operation(summary = "크루 참여 - 임시 API (추가 업데이트 예정)", description = "특정 사용자가 특정 크루에 참여할 때 사용")
-	@ApiResponses({
-		@ApiResponse(
-			responseCode = "200",
-			description = "해당 크루에 참여 완료"
-		)
-	})
-	CommonResponse joinCrew(@HereWeUser User user, @PathVariable Long crewId);
 }
 

--- a/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
+++ b/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
@@ -83,18 +83,18 @@ public class CrewController implements CrewApi {
 		return new SingleResponse<>(HttpStatus.OK, response);
 	}
 
-	@PostMapping("/invite/{token}")
-	public CommonResponse joinCrew(@HereWeUser User user, @PathVariable String inviteToken) {
-		invitationFacade.joinCrew(inviteToken);
-
-		return CommonResponse.ok();
-	}
-
 	@PostMapping("/invite")
 	public CommonResponse inviteCrew(
 		@Valid @RequestBody InvitationRequest invitationRequest) {
 
 		invitationFacade.inviteCrew(invitationRequest);
+
+		return CommonResponse.ok();
+	}
+
+	@PostMapping("/invite/{token}")
+	public CommonResponse joinCrew(@PathVariable(name = "token") String inviteToken) {
+		invitationFacade.joinCrew(inviteToken);
 
 		return CommonResponse.ok();
 	}

--- a/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
+++ b/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
@@ -18,6 +18,8 @@ import com.genius.herewe.business.crew.dto.CrewModifyRequest;
 import com.genius.herewe.business.crew.dto.CrewPreviewResponse;
 import com.genius.herewe.business.crew.dto.CrewResponse;
 import com.genius.herewe.business.crew.facade.CrewFacade;
+import com.genius.herewe.business.invitation.dto.InvitationRequest;
+import com.genius.herewe.business.invitation.facade.InvitationFacade;
 import com.genius.herewe.core.global.response.CommonResponse;
 import com.genius.herewe.core.global.response.PagingResponse;
 import com.genius.herewe.core.global.response.SingleResponse;
@@ -32,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CrewController implements CrewApi {
 	private final CrewFacade crewFacade;
+	private final InvitationFacade invitationFacade;
 
 	@GetMapping("/my")
 	public PagingResponse<CrewPreviewResponse> inquiryMyCrews(
@@ -80,9 +83,18 @@ public class CrewController implements CrewApi {
 		return new SingleResponse<>(HttpStatus.OK, response);
 	}
 
-	@PostMapping("/{crewId}/members")
-	public CommonResponse joinCrew(@HereWeUser User user, @PathVariable Long crewId) {
-		crewFacade.joinCrew(user.getId(), crewId);
+	@PostMapping("/invite/{token}")
+	public CommonResponse joinCrew(@HereWeUser User user, @PathVariable String inviteToken) {
+		invitationFacade.joinCrew(inviteToken);
+
+		return CommonResponse.ok();
+	}
+
+	@PostMapping("/invite")
+	public CommonResponse inviteCrew(
+		@Valid @RequestBody InvitationRequest invitationRequest) {
+
+		invitationFacade.inviteCrew(invitationRequest);
 
 		return CommonResponse.ok();
 	}

--- a/src/main/java/com/genius/herewe/business/crew/domain/Crew.java
+++ b/src/main/java/com/genius/herewe/business/crew/domain/Crew.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.hibernate.annotations.ColumnDefault;
 
 import com.genius.herewe.business.chat.domain.ChatRoom;
+import com.genius.herewe.business.invitation.domain.Invitation;
 import com.genius.herewe.business.notice.domain.Notice;
 import com.genius.herewe.core.global.domain.BaseTimeEntity;
 import com.genius.herewe.infra.file.domain.FileHolder;
@@ -40,6 +41,9 @@ public class Crew extends BaseTimeEntity implements FileHolder {
 
 	@OneToMany(mappedBy = "crew", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<CrewMember> crewMembers = new ArrayList<>();
+
+	@OneToMany(mappedBy = "crew", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Invitation> invitations = new ArrayList<>();
 
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "chat_room_id")

--- a/src/main/java/com/genius/herewe/business/crew/facade/CrewFacade.java
+++ b/src/main/java/com/genius/herewe/business/crew/facade/CrewFacade.java
@@ -19,6 +19,4 @@ public interface CrewFacade {
 	CrewPreviewResponse createCrew(Long userId, CrewCreateRequest request);
 
 	CrewPreviewResponse modifyCrew(Long userId, Long crewId, CrewModifyRequest request);
-
-	void joinCrew(Long userId, Long crewId);
 }

--- a/src/main/java/com/genius/herewe/business/crew/facade/DefaultCrewFacade.java
+++ b/src/main/java/com/genius/herewe/business/crew/facade/DefaultCrewFacade.java
@@ -1,9 +1,5 @@
 package com.genius.herewe.business.crew.facade;
 
-import static com.genius.herewe.core.global.exception.ErrorCode.*;
-
-import java.util.Optional;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -88,22 +84,5 @@ public class DefaultCrewFacade implements CrewFacade {
 
 		crew.modify(request.name(), request.introduce());
 		return CrewPreviewResponse.create(crew);
-	}
-
-	@Override
-	@Transactional
-	public void joinCrew(Long userId, Long crewId) {
-		User user = userService.findById(userId);
-		Crew crew = crewService.findById(crewId);
-
-		Optional<CrewMember> optionalCrewMember = crewMemberService.findOptional(userId, crewId);
-		if (optionalCrewMember.isPresent()) {
-			throw new BusinessException(ALREADY_JOINED_CREW);
-		}
-
-		CrewMember crewMember = CrewMember.createByRole(CrewRole.MEMBER);
-		crewMember.joinCrew(user, crew);
-
-		crewMemberService.save(crewMember);
 	}
 }

--- a/src/main/java/com/genius/herewe/business/invitation/domain/Invitation.java
+++ b/src/main/java/com/genius/herewe/business/invitation/domain/Invitation.java
@@ -1,7 +1,6 @@
 package com.genius.herewe.business.invitation.domain;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 import com.genius.herewe.business.crew.domain.Crew;
 import com.genius.herewe.core.user.domain.User;
@@ -50,13 +49,11 @@ public class Invitation {
 		this.token = token;
 	}
 
-	public static Invitation create(long expirationDays) {
-		LocalDateTime now = LocalDateTime.now();
-		String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+	public static Invitation create(String token, LocalDateTime invitedAt, LocalDateTime expiredAt) {
 		return Invitation.builder()
-			.invitedAt(now)
-			.expiredAt(now.plusDays(expirationDays))
-			.token(uuid)
+			.invitedAt(invitedAt)
+			.expiredAt(expiredAt)
+			.token(token)
 			.build();
 	}
 
@@ -73,9 +70,9 @@ public class Invitation {
 	}
 
 	//== 비지니스 로직 ==//
-	public void update(Invitation updated) {
-		this.token = updated.getToken();
-		this.invitedAt = updated.getInvitedAt();
-		this.expiredAt = updated.getExpiredAt();
+	public void update(String token, LocalDateTime invitedAt, LocalDateTime expiredAt) {
+		this.token = token;
+		this.invitedAt = invitedAt;
+		this.expiredAt = expiredAt;
 	}
 }

--- a/src/main/java/com/genius/herewe/business/invitation/domain/Invitation.java
+++ b/src/main/java/com/genius/herewe/business/invitation/domain/Invitation.java
@@ -1,0 +1,81 @@
+package com.genius.herewe.business.invitation.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.genius.herewe.business.crew.domain.Crew;
+import com.genius.herewe.core.user.domain.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Invitation {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "crew_id")
+	private Crew crew;
+
+	@Column(unique = true, nullable = false)
+	private String token;
+
+	private LocalDateTime invitedAt;
+
+	@Column(nullable = false)
+	private LocalDateTime expiredAt;
+
+	@Builder
+	public Invitation(LocalDateTime invitedAt, LocalDateTime expiredAt, String token) {
+		this.expiredAt = expiredAt;
+		this.invitedAt = invitedAt;
+		this.token = token;
+	}
+
+	public static Invitation create(long expirationDays) {
+		LocalDateTime now = LocalDateTime.now();
+		String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+		return Invitation.builder()
+			.invitedAt(now)
+			.expiredAt(now.plusDays(expirationDays))
+			.token(uuid)
+			.build();
+	}
+
+	//== 연관관계 편의 메서드 ==//
+	public void inviteUser(User user, Crew crew) {
+		this.user = user;
+		this.crew = crew;
+		if (!user.getInvitations().contains(this)) {
+			user.getInvitations().add(this);
+		}
+		if (!crew.getInvitations().contains(this)) {
+			crew.getInvitations().add(this);
+		}
+	}
+
+	//== 비지니스 로직 ==//
+	public void update(Invitation updated) {
+		this.token = updated.getToken();
+		this.invitedAt = updated.getInvitedAt();
+		this.expiredAt = updated.getExpiredAt();
+	}
+}

--- a/src/main/java/com/genius/herewe/business/invitation/domain/InvitationStatus.java
+++ b/src/main/java/com/genius/herewe/business/invitation/domain/InvitationStatus.java
@@ -1,0 +1,8 @@
+package com.genius.herewe.business.invitation.domain;
+
+public enum InvitationStatus {
+	PENDING,
+	ACCEPTED,
+	REJECTED, // temp function
+	EXPIRED
+}

--- a/src/main/java/com/genius/herewe/business/invitation/dto/InvitationInfo.java
+++ b/src/main/java/com/genius/herewe/business/invitation/dto/InvitationInfo.java
@@ -1,0 +1,24 @@
+package com.genius.herewe.business.invitation.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder
+public record InvitationInfo(
+	String token,
+	LocalDateTime invitedAt,
+	LocalDateTime expiredAt
+) {
+
+	public static InvitationInfo create(int duration) {
+		LocalDateTime now = LocalDateTime.now();
+		String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+		return InvitationInfo.builder()
+			.invitedAt(now)
+			.expiredAt(now.plusDays(duration))
+			.token(uuid)
+			.build();
+	}
+}

--- a/src/main/java/com/genius/herewe/business/invitation/dto/InvitationRequest.java
+++ b/src/main/java/com/genius/herewe/business/invitation/dto/InvitationRequest.java
@@ -1,0 +1,12 @@
+package com.genius.herewe.business.invitation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "크루 초대 요청 DTO")
+public record InvitationRequest(
+	@Schema(description = "초대할 크루의 식별자(PK)", example = "1")
+	Long crewId,
+	@Schema(description = "크루 초대를 받을 사용자의 닉네임", example = "HEY")
+	String nickname
+) {
+}

--- a/src/main/java/com/genius/herewe/business/invitation/facade/DefaultInvitationFacade.java
+++ b/src/main/java/com/genius/herewe/business/invitation/facade/DefaultInvitationFacade.java
@@ -103,7 +103,8 @@ public class DefaultInvitationFacade implements InvitationFacade {
 		// 3-1. 없거나 expiredAt이 현재 시간을 이미 지난 경우 -> 예외 발생, 유효기간이 지났습니다 + 엔티티 삭제
 		// 3-2. 있으며 expiredAt이 현재 시간을 안 지난 경우 -> 다음 로직 실행
 		Invitation invitation = invitationService.findByToken(inviteToken);
-		if (invitation.getExpiredAt().isAfter(LocalDateTime.now())) {
+		if (invitation.getExpiredAt().isBefore(LocalDateTime.now())) {
+			invitationService.delete(invitation);
 			throw new BusinessException(INVITATION_EXPIRED);
 		}
 		// N+1 problem 확인해보기

--- a/src/main/java/com/genius/herewe/business/invitation/facade/DefaultInvitationFacade.java
+++ b/src/main/java/com/genius/herewe/business/invitation/facade/DefaultInvitationFacade.java
@@ -1,0 +1,125 @@
+package com.genius.herewe.business.invitation.facade;
+
+import static com.genius.herewe.core.global.exception.ErrorCode.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.genius.herewe.business.crew.domain.Crew;
+import com.genius.herewe.business.crew.domain.CrewMember;
+import com.genius.herewe.business.crew.domain.CrewRole;
+import com.genius.herewe.business.crew.service.CrewMemberService;
+import com.genius.herewe.business.crew.service.CrewService;
+import com.genius.herewe.business.invitation.domain.Invitation;
+import com.genius.herewe.business.invitation.dto.InvitationRequest;
+import com.genius.herewe.business.invitation.service.InvitationService;
+import com.genius.herewe.core.global.exception.BusinessException;
+import com.genius.herewe.core.user.domain.User;
+import com.genius.herewe.core.user.service.UserService;
+import com.genius.herewe.infra.mail.dto.MailRequest;
+import com.genius.herewe.infra.mail.service.MailManager;
+
+@Service
+@Transactional(readOnly = true)
+public class DefaultInvitationFacade implements InvitationFacade {
+	private final String BASE_URL;
+	private final String INVITE_URL;
+	private final UserService userService;
+	private final CrewService crewService;
+	private final CrewMemberService crewMemberService;
+	private final InvitationService invitationService;
+	private final MailManager mailManager;
+
+	public DefaultInvitationFacade(@Value("${url.base}") String BASE_URL,
+		@Value("${url.path.invite}") String INVITE_URL,
+		UserService userService, CrewService crewService,
+		CrewMemberService crewMemberService,
+		InvitationService invitationService, MailManager mailManager) {
+		this.BASE_URL = BASE_URL;
+		this.INVITE_URL = INVITE_URL;
+		this.userService = userService;
+		this.crewService = crewService;
+		this.crewMemberService = crewMemberService;
+		this.invitationService = invitationService;
+		this.mailManager = mailManager;
+	}
+
+	@Override
+	@Transactional
+	public void inviteCrew(InvitationRequest invitationRequest) {
+		// 1. user Nickname 존재 여부 확인 -> 없으면 존재하지 않는 사용자, 있으면 이메일 추출
+		String nickname = invitationRequest.nickname();
+
+		User user = userService.findByNickname(nickname)
+			.orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
+		// 3. crewId를 통해 Crew에서 필요한 정보(이름, 소개글, 참여인원) 추출
+		Crew crew = crewService.findById(invitationRequest.crewId());
+
+		// 2. CrewMember 여부 확인 -> 있으면 이미 크루에 참여해 있는 사용자
+		if (crewMemberService.findOptional(user.getId(), crew.getId()).isPresent()) {
+			throw new BusinessException(ALREADY_JOINED_CREW);
+		}
+
+		// 3. Invitation 여부 확인
+		// 3-1. 있으며 expiredAt이 아직 지나지 않은 경우 -> 재발송하고 Invitation 정보 갱신하기 (기존 토큰으로 참여 시도 시 예외 처리 필요)
+		//      OR 예외를 발생하고 사용자에게 재발송할건지 확인받기
+		// 3-2. 없는 경우 다음 로직 실행
+		// 3-3. 있지만 expiredAt이 지난 경우 -> expiredAt만 갱신하면 됨
+		// 일단 Invitation 생성하기
+		Invitation newInvitation = Invitation.create(2);
+		newInvitation.inviteUser(user, crew);
+
+		Invitation invitation = invitationService.findOptional(user.getId(), crew.getId())
+			.map(existingInvitation -> {
+				existingInvitation.update(newInvitation);
+				return existingInvitation;
+			})
+			.orElseGet(() -> newInvitation);
+
+		// 4. mailManager를 통해 메일 전송
+		// 추후 비동기 처리 필요 -> 콜백 여부에 따라 Invitation 추가 처리 필요
+		MailRequest mailRequest = MailRequest.builder()
+			.receiverMail(user.getEmail())
+			.nickname(nickname)
+			.crewName(crew.getName())
+			.introduce(crew.getIntroduce())
+			.memberCount(crew.getParticipantCount())
+			.inviteUrl(BASE_URL + INVITE_URL + invitation.getToken())
+			.build();
+		mailManager.send(mailRequest);
+
+		// 5. (동기) 메일 전송이 완료되면 Invitation 엔티티 저장
+		invitationService.save(invitation);
+	}
+
+	// 수정 필요
+	@Transactional
+	public void joinCrew(String inviteToken) {
+		// 3. Invitation 여부 확인
+		// 3-1. 없거나 expiredAt이 현재 시간을 이미 지난 경우 -> 예외 발생, 유효기간이 지났습니다 + 엔티티 삭제
+		// 3-2. 있으며 expiredAt이 현재 시간을 안 지난 경우 -> 다음 로직 실행
+		Invitation invitation = invitationService.findByToken(inviteToken);
+		if (invitation.getExpiredAt().isAfter(LocalDateTime.now())) {
+			throw new BusinessException(INVITATION_EXPIRED);
+		}
+		// N+1 problem 확인해보기
+		User user = userService.findById(invitation.getUser().getId());
+		Crew crew = crewService.findById(invitation.getCrew().getId());
+
+		Optional<CrewMember> optionalCrewMember = crewMemberService.findOptional(user.getId(), crew.getId());
+		if (optionalCrewMember.isPresent()) {
+			throw new BusinessException(ALREADY_JOINED_CREW);
+
+		}
+
+		CrewMember crewMember = CrewMember.createByRole(CrewRole.MEMBER);
+		crewMember.joinCrew(user, crew);
+
+		crewMemberService.save(crewMember);
+		invitationService.delete(invitation);
+	}
+}

--- a/src/main/java/com/genius/herewe/business/invitation/facade/InvitationFacade.java
+++ b/src/main/java/com/genius/herewe/business/invitation/facade/InvitationFacade.java
@@ -1,0 +1,9 @@
+package com.genius.herewe.business.invitation.facade;
+
+import com.genius.herewe.business.invitation.dto.InvitationRequest;
+
+public interface InvitationFacade {
+	void inviteCrew(InvitationRequest invitationRequest);
+
+	void joinCrew(String inviteToken);
+}

--- a/src/main/java/com/genius/herewe/business/invitation/repository/InvitationRepository.java
+++ b/src/main/java/com/genius/herewe/business/invitation/repository/InvitationRepository.java
@@ -1,0 +1,18 @@
+package com.genius.herewe.business.invitation.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.genius.herewe.business.invitation.domain.Invitation;
+
+public interface InvitationRepository extends JpaRepository<Invitation, Long> {
+
+	@Query("SELECT i FROM Invitation i WHERE i.user.id = :userId AND i.crew.id = :crewId")
+	Optional<Invitation> findOptional(@Param("userId") Long userId, @Param("crewId") Long crewId);
+
+	@Query("SELECT i FROM Invitation i WHERE i.token = :token")
+	Optional<Invitation> findOptionalByToken(@Param("token") String token);
+}

--- a/src/main/java/com/genius/herewe/business/invitation/service/InvitationService.java
+++ b/src/main/java/com/genius/herewe/business/invitation/service/InvitationService.java
@@ -1,0 +1,40 @@
+package com.genius.herewe.business.invitation.service;
+
+import static com.genius.herewe.core.global.exception.ErrorCode.*;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.genius.herewe.business.invitation.domain.Invitation;
+import com.genius.herewe.business.invitation.repository.InvitationRepository;
+import com.genius.herewe.core.global.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class InvitationService {
+	private final InvitationRepository invitationRepository;
+
+	@Transactional
+	public Invitation save(Invitation invitation) {
+		return invitationRepository.save(invitation);
+	}
+
+	public Optional<Invitation> findOptional(Long userId, Long crewId) {
+		return invitationRepository.findOptional(userId, crewId);
+	}
+
+	public Invitation findByToken(String token) {
+		return invitationRepository.findOptionalByToken(token)
+			.orElseThrow(() -> new BusinessException(INVITATION_NOT_FOUND));
+	}
+
+	@Transactional
+	public void delete(Invitation invitation) {
+		invitationRepository.delete(invitation);
+	}
+}

--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -21,7 +21,7 @@ public enum ErrorCode {
 	ALREADY_JOINED_CREW(HttpStatus.BAD_REQUEST, "이미 참여한 크루입니다."),
 
 	ALREADY_INVITED(HttpStatus.BAD_REQUEST, "이미 해당 크루에 초대되었습니다."),
-	INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "크루 초대 정보를 찾을 수 없습니다. 초대를 다시 요청해주세요."),
+	INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "크루 초대 정보를 찾을 수 없습니다. 초대 정보를 다시 확인해주세요."),
 	INVITATION_EXPIRED(HttpStatus.BAD_REQUEST, "크루 초대가 만료되었습니다."),
 
 	UNAUTHORIZED_ISSUE(HttpStatus.UNAUTHORIZED, "회원가입이 되어 있지 않은 사용자의 경우 JWT를 발급할 수 없습니다."),

--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -20,6 +20,10 @@ public enum ErrorCode {
 	CREW_JOIN_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 크루에 대한 참여 정보가 없습니다."),
 	ALREADY_JOINED_CREW(HttpStatus.BAD_REQUEST, "이미 참여한 크루입니다."),
 
+	ALREADY_INVITED(HttpStatus.BAD_REQUEST, "이미 해당 크루에 초대되었습니다."),
+	INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "크루 초대 정보를 찾을 수 없습니다."),
+	INVITATION_EXPIRED(HttpStatus.BAD_REQUEST, "크루 초대가 만료되었습니다."),
+
 	UNAUTHORIZED_ISSUE(HttpStatus.UNAUTHORIZED, "회원가입이 되어 있지 않은 사용자의 경우 JWT를 발급할 수 없습니다."),
 	JWT_NOT_VALID(HttpStatus.UNAUTHORIZED, "JWT가 유효하지 않습니다."),
 	JWT_NOT_FOUND_IN_HEADER(HttpStatus.UNAUTHORIZED, "Header에서 JWT를 찾을 수 없습니다."),

--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -21,7 +21,7 @@ public enum ErrorCode {
 	ALREADY_JOINED_CREW(HttpStatus.BAD_REQUEST, "이미 참여한 크루입니다."),
 
 	ALREADY_INVITED(HttpStatus.BAD_REQUEST, "이미 해당 크루에 초대되었습니다."),
-	INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "크루 초대 정보를 찾을 수 없습니다."),
+	INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "크루 초대 정보를 찾을 수 없습니다. 초대를 다시 요청해주세요."),
 	INVITATION_EXPIRED(HttpStatus.BAD_REQUEST, "크루 초대가 만료되었습니다."),
 
 	UNAUTHORIZED_ISSUE(HttpStatus.UNAUTHORIZED, "회원가입이 되어 있지 않은 사용자의 경우 JWT를 발급할 수 없습니다."),

--- a/src/main/java/com/genius/herewe/core/user/domain/User.java
+++ b/src/main/java/com/genius/herewe/core/user/domain/User.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.genius.herewe.business.crew.domain.CrewMember;
+import com.genius.herewe.business.invitation.domain.Invitation;
 import com.genius.herewe.business.moment.domain.MomentMember;
 import com.genius.herewe.infra.file.domain.FileHolder;
 import com.genius.herewe.infra.file.domain.Files;
@@ -41,6 +42,9 @@ public class User implements FileHolder {
 
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<MomentMember> momentMembers = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Invitation> invitations = new ArrayList<>();
 
 	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
 	@JoinColumn(name = "files_id")

--- a/src/main/java/com/genius/herewe/infra/mail/dto/MailRequest.java
+++ b/src/main/java/com/genius/herewe/infra/mail/dto/MailRequest.java
@@ -1,0 +1,14 @@
+package com.genius.herewe.infra.mail.dto;
+
+import lombok.Builder;
+
+@Builder
+public record MailRequest(
+	String receiver,
+	String nickname,
+	String crewName,
+	String introduce,
+	int memberCount,
+	String inviteUrl
+) {
+}

--- a/src/main/java/com/genius/herewe/infra/mail/dto/MailRequest.java
+++ b/src/main/java/com/genius/herewe/infra/mail/dto/MailRequest.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record MailRequest(
-	String receiver,
+	String receiverMail,
 	String nickname,
 	String crewName,
 	String introduce,

--- a/src/main/java/com/genius/herewe/infra/mail/service/MailManager.java
+++ b/src/main/java/com/genius/herewe/infra/mail/service/MailManager.java
@@ -1,0 +1,43 @@
+package com.genius.herewe.infra.mail.service;
+
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import com.genius.herewe.infra.mail.dto.MailRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MailManager {
+	private final JavaMailSender mailSender;
+	private final TemplateEngine templateEngine;
+
+	public void send(MailRequest mailRequest) {
+		Context context = new Context();
+
+		context.setVariable("nickname", mailRequest.nickname());
+		context.setVariable("crewName", mailRequest.crewName());
+		context.setVariable("crewIntroduce", mailRequest.introduce());
+		context.setVariable("memberCount", mailRequest.memberCount());
+		context.setVariable("inviteUrl", mailRequest.inviteUrl());
+
+		MimeMessagePreparator preparatory = mimeMessage -> {
+			MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "UTF-8");
+
+			String content = templateEngine.process("crew-invitation", context);
+
+			helper.setTo(mailRequest.receiver());
+			helper.setFrom("genius.herewe@gmail.com", "HERE:WE");
+			helper.setSubject("[HERE:WE] 크루 초대가 도착했습니다 :)");
+
+			helper.setText(content, true);
+		};
+
+		mailSender.send(preparatory);
+	}
+}

--- a/src/main/java/com/genius/herewe/infra/mail/service/MailManager.java
+++ b/src/main/java/com/genius/herewe/infra/mail/service/MailManager.java
@@ -1,5 +1,6 @@
 package com.genius.herewe.infra.mail.service;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.mail.javamail.MimeMessagePreparator;
@@ -10,13 +11,18 @@ import org.thymeleaf.context.Context;
 import com.genius.herewe.core.global.exception.BusinessException;
 import com.genius.herewe.infra.mail.dto.MailRequest;
 
-import lombok.RequiredArgsConstructor;
-
 @Service
-@RequiredArgsConstructor
 public class MailManager {
+	private final String MAIL_ADDRESS;
 	private final JavaMailSender mailSender;
 	private final TemplateEngine templateEngine;
+
+	public MailManager(@Value("${spring.mail.username}") String MAIL_ADDRESS,
+		JavaMailSender mailSender, TemplateEngine templateEngine) {
+		this.MAIL_ADDRESS = MAIL_ADDRESS;
+		this.mailSender = mailSender;
+		this.templateEngine = templateEngine;
+	}
 
 	public void send(MailRequest mailRequest) {
 		Context context = new Context();
@@ -34,7 +40,7 @@ public class MailManager {
 				String content = templateEngine.process("crew-invitation", context);
 
 				helper.setTo(mailRequest.receiverMail());
-				helper.setFrom("genius.herewe@gmail.com", "HERE:WE");
+				helper.setFrom(MAIL_ADDRESS, "HERE:WE");
 				helper.setSubject("[HERE:WE] 크루 초대가 도착했습니다 :)");
 
 				helper.setText(content, true);

--- a/src/main/java/com/genius/herewe/infra/mail/service/MailManager.java
+++ b/src/main/java/com/genius/herewe/infra/mail/service/MailManager.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
+import com.genius.herewe.core.global.exception.BusinessException;
 import com.genius.herewe.infra.mail.dto.MailRequest;
 
 import lombok.RequiredArgsConstructor;
@@ -26,18 +27,22 @@ public class MailManager {
 		context.setVariable("memberCount", mailRequest.memberCount());
 		context.setVariable("inviteUrl", mailRequest.inviteUrl());
 
-		MimeMessagePreparator preparatory = mimeMessage -> {
-			MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "UTF-8");
+		try {
+			MimeMessagePreparator preparatory = mimeMessage -> {
+				MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "UTF-8");
 
-			String content = templateEngine.process("crew-invitation", context);
+				String content = templateEngine.process("crew-invitation", context);
 
-			helper.setTo(mailRequest.receiver());
-			helper.setFrom("genius.herewe@gmail.com", "HERE:WE");
-			helper.setSubject("[HERE:WE] 크루 초대가 도착했습니다 :)");
+				helper.setTo(mailRequest.receiverMail());
+				helper.setFrom("genius.herewe@gmail.com", "HERE:WE");
+				helper.setSubject("[HERE:WE] 크루 초대가 도착했습니다 :)");
 
-			helper.setText(content, true);
-		};
+				helper.setText(content, true);
+			};
 
-		mailSender.send(preparatory);
+			mailSender.send(preparatory);
+		} catch (Exception e) {
+			throw new BusinessException(e);
+		}
 	}
 }

--- a/src/main/resources/templates/crew-invitation.html
+++ b/src/main/resources/templates/crew-invitation.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <title>크루 초대 안내</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f9f9f9; color: #333; font-family: 'Malgun Gothic', 'Apple SD Gothic Neo', sans-serif;">
+
+<div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border: 1px solid #e0e0e0; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 10px rgba(0,0,0,0.05);">
+
+    <div style="background-color: #007BFF; color: white; padding: 20px; text-align: center; font-size: 22px; font-weight: bold;">
+        HERE:WE
+    </div>
+
+    <div style="padding: 30px 20px; text-align: center;">
+        <div style="font-size: 20px; font-weight: bold; margin-bottom: 25px; color: #333;">
+            🚀 크루 초대 링크 안내
+        </div>
+
+        <div style="margin-bottom: 25px; line-height: 1.6; font-size: 16px;">
+            안녕하세요, <span th:text="${nickname}">닉네임</span>님!<br>
+            아래 링크를 눌러 초대된 크루에 참여해주세요🥳
+        </div>
+
+        <div style="background-color: #f8f9fa; border-radius: 10px; padding: 25px; margin: 25px 0; text-align: left; border-left: 4px solid #007BFF; box-shadow: 0 2px 8px rgba(0,0,0,0.03);">
+            <div style="font-size: 22px; font-weight: bold; margin-bottom: 15px; color: #007BFF;">
+                🌟 <span th:text="${crewName}">크루 이름</span>
+            </div>
+            <div style="margin-bottom: 20px; line-height: 1.7; color: #444; font-size: 15px;">
+                <span th:text="${crewIntroduce}">크루 설명</span>
+            </div>
+            <div style="background-color: rgba(0, 123, 255, 0.08); border-radius: 50px; padding: 8px 15px; display: inline-block; margin-top: 10px; font-size: 14px; color: #007BFF;">
+                <strong>현재 참여인원:</strong> <span th:text="${memberCount}">0</span>명
+            </div>
+        </div>
+
+        <div style="margin: 35px 0 25px;">
+            <a style="background-color: #007BFF; color: white; padding: 16px 32px; font-size: 16px; font-weight: bold; text-decoration: none; display: inline-block; border-radius: 50px; cursor: pointer; border: none; transition: background-color 0.2s, transform 0.1s; box-shadow: 0 4px 8px rgba(0, 123, 255, 0.2);"
+               th:href="${inviteUrl}">
+                크루 참여하기
+            </a>
+        </div>
+
+        <div style="color: #777; margin-top: 25px; font-size: 14px; font-style: italic;">
+            이 초대 링크는 7일 후에 만료됩니다.
+        </div>
+    </div>
+
+    <div style="border-top: 1px solid #e0e0e0; padding: 20px; text-align: center; color: #888; font-size: 12px; background-color: #fafafa;">
+        본 메일은 HERE:WE 시스템에 의해 자동 발송되었습니다.<br>
+        &copy; 2025 HERE:WE. All Rights Reserved.
+    </div>
+</div>
+
+</body>
+</html>

--- a/src/test/java/com/genius/herewe/business/invitation/Fixture/InvitationFixture.java
+++ b/src/test/java/com/genius/herewe/business/invitation/Fixture/InvitationFixture.java
@@ -1,0 +1,53 @@
+package com.genius.herewe.business.invitation.Fixture;
+
+import java.time.LocalDateTime;
+
+import com.genius.herewe.business.invitation.domain.Invitation;
+
+public class InvitationFixture {
+	public static Invitation createDefault() {
+		return builder()
+			.build();
+	}
+
+	public static Invitation createExpired() {
+		LocalDateTime now = LocalDateTime.now();
+		return builder()
+			.invitedAt(now.minusDays(4))
+			.expiredAt(now.minusDays(2))
+			.build();
+	}
+
+	public static InvitationBuilder builder() {
+		return new InvitationBuilder();
+	}
+
+	public static class InvitationBuilder {
+		private String token = "invitation UUID token";
+		private LocalDateTime invitedAt = LocalDateTime.now();
+		private LocalDateTime expiredAt = LocalDateTime.now().plusDays(2);
+
+		public InvitationBuilder token(String token) {
+			this.token = token;
+			return this;
+		}
+
+		public InvitationBuilder invitedAt(LocalDateTime invitedAt) {
+			this.invitedAt = invitedAt;
+			return this;
+		}
+
+		public InvitationBuilder expiredAt(LocalDateTime expiredAt) {
+			this.expiredAt = expiredAt;
+			return this;
+		}
+
+		public Invitation build() {
+			return Invitation.builder()
+				.token(token)
+				.invitedAt(invitedAt)
+				.expiredAt(expiredAt)
+				.build();
+		}
+	}
+}

--- a/src/test/java/com/genius/herewe/business/invitation/facade/InvitationFacadeTest.java
+++ b/src/test/java/com/genius/herewe/business/invitation/facade/InvitationFacadeTest.java
@@ -1,0 +1,309 @@
+package com.genius.herewe.business.invitation.facade;
+
+import static com.genius.herewe.core.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.genius.herewe.business.crew.domain.Crew;
+import com.genius.herewe.business.crew.domain.CrewMember;
+import com.genius.herewe.business.crew.domain.CrewRole;
+import com.genius.herewe.business.crew.fixture.CrewFixture;
+import com.genius.herewe.business.crew.service.CrewMemberService;
+import com.genius.herewe.business.crew.service.CrewService;
+import com.genius.herewe.business.invitation.Fixture.InvitationFixture;
+import com.genius.herewe.business.invitation.domain.Invitation;
+import com.genius.herewe.business.invitation.dto.InvitationRequest;
+import com.genius.herewe.business.invitation.service.InvitationService;
+import com.genius.herewe.core.global.exception.BusinessException;
+import com.genius.herewe.core.user.domain.User;
+import com.genius.herewe.core.user.fixture.UserFixture;
+import com.genius.herewe.core.user.service.UserService;
+import com.genius.herewe.infra.mail.service.MailManager;
+
+@ExtendWith(MockitoExtension.class)
+class InvitationFacadeTest {
+	private InvitationFacade invitationFacade;
+	@Mock
+	private UserService userService;
+	@Mock
+	private CrewService crewService;
+	@Mock
+	private CrewMemberService crewMemberService;
+	@Mock
+	private InvitationService invitationService;
+	@Mock
+	private MailManager mailManager;
+	private User user;
+	private Crew crew;
+	private InvitationRequest invitationRequest;
+
+	@BeforeEach
+	void init() {
+		invitationFacade = new DefaultInvitationFacade("http://BASE_URL", "/invite/",
+			userService, crewService, crewMemberService, invitationService, mailManager);
+		user = UserFixture.createDefault();
+		crew = CrewFixture.createDefault();
+		invitationRequest = new InvitationRequest(crew.getId(), user.getNickname());
+	}
+
+	@Nested
+	@DisplayName("특정 사용자에게 크루 초대 요청 시")
+	class Context_when_invite_to_crew {
+
+		@Nested
+		@DisplayName("초대 대상의 닉네임을 전달했을 때")
+		class Describe_pass_nickname {
+			@Test
+			@DisplayName("존재하지 않는 닉네임이라면 MEMBER_NOT_FOUND 예외가 발생한다.")
+			public void it_throws_MEMBER_NOT_FOUND_exception() {
+				//given
+				String fakeNickname = "fake Nickname";
+				given(userService.findByNickname(fakeNickname)).willThrow(new BusinessException(MEMBER_NOT_FOUND));
+
+				//when & then
+				assertThatThrownBy(() -> invitationFacade.inviteCrew(
+					new InvitationRequest(crew.getId(), fakeNickname)
+				))
+					.isInstanceOf(BusinessException.class)
+					.hasMessageContaining(MEMBER_NOT_FOUND.getMessage());
+			}
+		}
+
+		@Nested
+		@DisplayName("초대할 크루의 식별자(PK)를 전달했을 때")
+		class Describe_pass_crew_PK {
+			@Test
+			@DisplayName("존재하지 않는다면 CREW_NOT_FOUND 예외가 발생한다.")
+			public void it_throws_CREW_NOT_FOUND_exception() {
+				//given
+				Long fakeCrewId = 999L;
+				given(userService.findByNickname(user.getNickname())).willReturn(Optional.of(user));
+				given(crewService.findById(fakeCrewId)).willThrow(new BusinessException(CREW_NOT_FOUND));
+
+				//when & then
+				assertThatThrownBy(() -> invitationFacade.inviteCrew(
+					new InvitationRequest(fakeCrewId, user.getNickname())
+				))
+					.isInstanceOf(BusinessException.class)
+					.hasMessageContaining(CREW_NOT_FOUND.getMessage());
+			}
+		}
+
+		@Nested
+		@DisplayName("크루 참여 정보를 조회했을 때")
+		class Describe_inquiry_crewMember {
+			@Test
+			@DisplayName("크루 참여 정보가 존재한다면 ALREADY_JOINED_CREW 예외가 발생한다.")
+			public void it_throws_ALREADY_JOINED_CREW_exception() {
+				//given
+				Long userId = user.getId();
+				Long crewId = crew.getId();
+				given(userService.findByNickname(user.getNickname())).willReturn(Optional.of(user));
+				given(crewService.findById(crew.getId())).willReturn(crew);
+				given(crewMemberService.findOptional(userId, crewId)).willReturn(
+					Optional.of(CrewMember.createByRole(CrewRole.MEMBER)));
+
+				//when & then
+				assertThatThrownBy(() -> invitationFacade.inviteCrew(invitationRequest))
+					.isInstanceOf(BusinessException.class)
+					.hasMessageContaining(ALREADY_JOINED_CREW.getMessage());
+			}
+		}
+
+		@Nested
+		@DisplayName("초대 엔티티를 조회했을 때")
+		class Describe_inquiry_invitation {
+			Long userId;
+			Long crewId;
+			@Captor
+			private ArgumentCaptor<Invitation> invitationCaptor;
+
+			@BeforeEach
+			void init() {
+				userId = user.getId();
+				crewId = crew.getId();
+				given(userService.findByNickname(user.getNickname())).willReturn(Optional.of(user));
+				given(crewService.findById(crew.getId())).willReturn(crew);
+				given(crewMemberService.findOptional(userId, crewId)).willReturn(Optional.empty());
+			}
+
+			@Test
+			@DisplayName("기존에 존재하지 않았다면 새로운 Invitation 엔티티를 생성한다.")
+			public void it_return_new_invitation_entity() {
+				//given
+				given(invitationService.findOptional(userId, crewId)).willReturn(Optional.empty());
+
+				//when
+				invitationFacade.inviteCrew(invitationRequest);
+
+				//then
+				verify(invitationService).save(invitationCaptor.capture());
+				Invitation savedInvitation = invitationCaptor.getValue();
+
+				assertThat(savedInvitation.getToken()).isNotNull();
+				assertThat(savedInvitation.getInvitedAt()).isNotNull();
+				assertThat(savedInvitation.getExpiredAt()).isAfter(LocalDateTime.now());
+			}
+
+			@Test
+			@DisplayName("기존에 존재했으나 expiredAt이 지나지 않은 경우, token, invitedAt, expiredAt이 갱신된다.")
+			public void it_update_invitation() {
+				//given
+				Invitation existInvitation = InvitationFixture.createDefault();
+				existInvitation.inviteUser(user, crew);
+				String inviteToken = existInvitation.getToken();
+				LocalDateTime invitedAt = existInvitation.getInvitedAt();
+				LocalDateTime expiredAt = existInvitation.getExpiredAt();
+
+				given(invitationService.findOptional(userId, crewId)).willReturn(Optional.of(existInvitation));
+
+				//when
+				invitationFacade.inviteCrew(invitationRequest);
+
+				//then
+				verify(invitationService).save(invitationCaptor.capture());
+				Invitation updatedInvitation = invitationCaptor.getValue();
+
+				assertThat(updatedInvitation.getToken()).isNotEqualTo(inviteToken);
+				assertThat(updatedInvitation.getInvitedAt()).isNotEqualTo(invitedAt);
+				assertThat(updatedInvitation.getExpiredAt()).isNotEqualTo(expiredAt);
+				assertThat(updatedInvitation.getExpiredAt()).isAfter(LocalDateTime.now());
+			}
+
+			@Test
+			@DisplayName("기존에 존재했고 expiredAt이 지난 경우, token, invitedAt, expiredAt이 갱신된다.")
+			public void it_update_only_expiredAt() {
+				//given
+				Invitation existInvitation = InvitationFixture.createExpired();
+				existInvitation.inviteUser(user, crew);
+				String inviteToken = existInvitation.getToken();
+				LocalDateTime invitedAt = existInvitation.getInvitedAt();
+				LocalDateTime expiredAt = existInvitation.getExpiredAt();
+
+				//when
+				invitationFacade.inviteCrew(invitationRequest);
+
+				//then
+				verify(invitationService).save(invitationCaptor.capture());
+				Invitation updatedInvitation = invitationCaptor.getValue();
+
+				assertThat(updatedInvitation.getToken()).isNotEqualTo(inviteToken);
+				assertThat(updatedInvitation.getInvitedAt()).isNotEqualTo(invitedAt);
+				assertThat(updatedInvitation.getExpiredAt()).isNotEqualTo(expiredAt);
+				assertThat(updatedInvitation.getExpiredAt()).isAfter(LocalDateTime.now());
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("초대 토큰을 통해 크루 참여 요청 시")
+	class Context_request_join_crew_by_token {
+		Long userId;
+		Long crewId;
+
+		@BeforeEach
+		void init() {
+			userId = user.getId();
+			crewId = crew.getId();
+		}
+
+		@Nested
+		@DisplayName("토큰을 통해 Invitation 엔티티 조회 시")
+		class Describe_inquiry_invitation_by_token {
+			@Test
+			@DisplayName("Invitation 엔티티를 찾을 수 없다면 INVITATION_NOT_FOUND 예외가 발생한다.")
+			public void it_throws_INVITATION_NOT_FOUND_exception() {
+				//given
+				String invalidToken = "invalid invitation token";
+				given(invitationService.findByToken(invalidToken)).willThrow(
+					new BusinessException(INVITATION_NOT_FOUND));
+
+				//when & then
+				assertThatThrownBy(() -> invitationFacade.joinCrew(invalidToken))
+					.isInstanceOf(BusinessException.class)
+					.hasMessageContaining(INVITATION_NOT_FOUND.getMessage());
+			}
+
+			@Test
+			@DisplayName("Invitation의 expiredAt이 만료되었다면 INVITATION_EXPIRED 예외를 발생한다.")
+			public void it_throws_INVITATION_EXPIRED_exception() {
+				//given
+				Invitation expiredInvitation = InvitationFixture.createExpired();
+				String expiredToken = expiredInvitation.getToken();
+
+				given(invitationService.findByToken(expiredToken)).willReturn(expiredInvitation);
+
+				//when & then
+				assertThatThrownBy(() -> invitationFacade.joinCrew(expiredToken))
+					.isInstanceOf(BusinessException.class)
+					.hasMessageContaining(INVITATION_EXPIRED.getMessage());
+			}
+		}
+
+		@Nested
+		@DisplayName("참여 정보를 조회했을 때")
+		class Describe_inquiry_crewMember {
+			@BeforeEach
+			void init() {
+				given(userService.findById(userId)).willReturn(user);
+				given(crewService.findById(crew.getId())).willReturn(crew);
+				given(crewMemberService.findOptional(userId, crewId)).willReturn(Optional.empty());
+			}
+
+			@Test
+			@DisplayName("참여 정보가 이미 존재한다면 ALREADY_JOINED_CREW 예외가 발생한다.")
+			public void it_throws_ALREADY_JOINED_CREW_exception() {
+				//given
+				Invitation invitation = InvitationFixture.createDefault();
+				invitation.inviteUser(user, crew);
+				CrewMember crewMember = CrewMember.createByRole(CrewRole.MEMBER);
+
+				given(invitationService.findByToken(invitation.getToken())).willReturn(invitation);
+				given(crewMemberService.findOptional(userId, crewId)).willReturn(Optional.of(crewMember));
+
+				//when & then
+				assertThatThrownBy(() -> invitationFacade.joinCrew(invitation.getToken()))
+					.isInstanceOf(BusinessException.class)
+					.hasMessageContaining(ALREADY_JOINED_CREW.getMessage());
+			}
+
+			@Test
+			@DisplayName("참여 정보가 존재하지 않는다면 새로운 CrewMember 엔티티를 저장하고, Invitation 엔티티를 삭제한다.")
+			public void it_save_crewMember_and_delete_invitation() {
+				//given
+				Invitation invitation = InvitationFixture.createDefault();
+				invitation.inviteUser(user, crew);
+				String invitationToken = invitation.getToken();
+
+				given(invitationService.findByToken(invitationToken)).willReturn(invitation);
+				given(crewMemberService.findOptional(userId, crewId)).willReturn(Optional.empty());
+
+				ArgumentCaptor<CrewMember> crewMemberCaptor = ArgumentCaptor.forClass(CrewMember.class);
+
+				//when
+				invitationFacade.joinCrew(invitationToken);
+
+				//then
+				verify(crewMemberService).save(crewMemberCaptor.capture());
+				verify(invitationService).delete(invitation);
+				CrewMember savedCrewMember = crewMemberCaptor.getValue();
+				assertThat(savedCrewMember.getUser().getId()).isEqualTo(userId);
+				assertThat(savedCrewMember.getCrew().getId()).isEqualTo(crewId);
+				assertThat(savedCrewMember.getJoinedAt()).isNotNull();
+			}
+		}
+	}
+}


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/40-invite-crew` -> `main`

</br>

### 🛠️ 변경 사항
#### 📋 어떤 기능인가요?
> 크루원 초대 API를 개발합니다.
> 1차 개발에서는 크루 리더가 크루원을 초대해야 크루에 참여 가능
> JavaMailSender를 통해 초대 링크를 보내고, 해당 링크를 통해 초대 요청을 하도록 처리

#### ✅ 작업 상세 내용
- [x] JavaMailSender를 통해 특정 사용자에게 초대 메일 보내는 기능 구현
    - [x] crew-invitation.html의 폼으로 사용자에게 메일 전송
    - [x] MailManager에 메일을 보내는 코드 추가
- [x] 크루에 사용자 초대, 크루 가입 API 구현
    - [x] InvitationFacade 클래스로 분리
- [x] InvitationFacade 테스트 코드 작성
- [x] git submodule 갱신
- [x] JavaMailSender, Thymeleaf 의존성 추가


</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/46b2df62-ab72-4a7a-9200-cd5f7ee0ac36)

</br>

### 📚 연관된 이슈
#40

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
