### PR TITLE
[FEAT] 크루 초대 API에 비동기 적용

### DIFF
--- a/src/main/java/com/genius/herewe/business/invitation/service/InvitationService.java
+++ b/src/main/java/com/genius/herewe/business/invitation/service/InvitationService.java
@@ -5,6 +5,7 @@ import static com.genius.herewe.core.global.exception.ErrorCode.*;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.genius.herewe.business.invitation.domain.Invitation;
@@ -35,6 +36,11 @@ public class InvitationService {
 
 	@Transactional
 	public void delete(Invitation invitation) {
+		invitationRepository.delete(invitation);
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void deleteInNewTransaction(Invitation invitation) {
 		invitationRepository.delete(invitation);
 	}
 }

--- a/src/main/java/com/genius/herewe/core/global/config/AsyncConfig.java
+++ b/src/main/java/com/genius/herewe/core/global/config/AsyncConfig.java
@@ -1,0 +1,41 @@
+package com.genius.herewe.core.global.config;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import com.genius.herewe.core.global.exception.AsyncExceptionHandler;
+
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+	private int CORE_POOL_SIZE = 10; // 스레드 풀의 코어 스레드 수
+	private int MAX_POOL_SIZE = 30; // 스레드 풀의 최대 스레드 수
+	private int QUEUE_CAPACITY = 10000; // 작업 큐의 용량
+
+	@Bean(name = "threadExecutor")
+	public Executor threadPoolTaskExecutor() {
+		ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+
+		taskExecutor.setCorePoolSize(CORE_POOL_SIZE);
+		taskExecutor.setMaxPoolSize(MAX_POOL_SIZE);
+		taskExecutor.setQueueCapacity(QUEUE_CAPACITY);
+		taskExecutor.setThreadNamePrefix("Executor-");
+		taskExecutor.initialize();
+
+		// NOTE: SecurityContext, 사용자 컨텍스트 전파 필요 시 Decorator 도입하기
+
+		taskExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+
+		return taskExecutor;
+	}
+
+	@Override
+	public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+		return new AsyncExceptionHandler();
+	}
+}

--- a/src/main/java/com/genius/herewe/core/global/exception/AsyncExceptionHandler.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/AsyncExceptionHandler.java
@@ -1,0 +1,15 @@
+package com.genius.herewe.core.global.exception;
+
+import java.lang.reflect.Method;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+	@Override
+	public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+		log.error(ex.getMessage(), ex); // 예외 메시지와 스택 트레이스를 로깅
+	}
+}


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/43-apply-async-crew-invite` -> `main`

</br>

### 🛠️ 변경 사항
> 크루 초대 API에 비동기를 적용합니다.
> 기존의 방식은 JavaMailSender 사용으로 인해 API 응답 시간이 평균 4초로 매우 길어, 비동기를 적용해서 성능을 개선합니다.

#### ✅ 작업 상세 내용
- [x] 비동기 Configutation 클래스 작성 - AsyncConfig
- [x] MailManager에 메일을 비동기적으로 보내는 `sendAsync()` 메서드 추가
    - [x] 콜백 메서드를 통해 결과를 받아서, 메일 전송에 실패한 경우 Invitation 정보를 삭제하도록 설정
    - [x] 이를 위해 InvitationService에 새로운 트랜잭션에서 엔티티를 삭제하는 `deleteInNewTransaction()` 메서드 추가
- [x] InvitationFacade 테스트 코드 수정 (크루 초대 부분)
</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/f2fd2be2-f6d5-40be-82d5-886bc462cd02)


</br>

### 📚 연관된 이슈
#43

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
