### PR TITLE
[FEAT] 크루원 내보내기 기능 개발

### DIFF
--- a/src/main/java/com/genius/herewe/business/crew/controller/CrewApi.java
+++ b/src/main/java/com/genius/herewe/business/crew/controller/CrewApi.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.genius.herewe.business.crew.dto.CrewCreateRequest;
 import com.genius.herewe.business.crew.dto.CrewMemberResponse;
@@ -331,5 +332,92 @@ public interface CrewApi {
 	})
 	CommonResponse joinCrew(@PathVariable String inviteToken);
 
+	@Operation(summary = "크루원 내보내기", description = "크루에서 특정 크루원 내보내기")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "크루에서 특정 크루원 내보내기 성공"
+		),
+		@ApiResponse(
+			responseCode = "400",
+			description = "크루 리더에 대해 크루 내보내기를 요청했을 때",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = @ExampleObject(
+					name = "크루 리더에 대해 크루 내보내기를 요청했을 때",
+					value = """
+						{
+							"resultCode": 400,
+							"code": "LEADER_CANNOT_EXPEL",
+							"message"; "CREW LEADER는 CREW에서 탈퇴할 수 없습니다."
+						}
+						"""
+				)
+			)
+		),
+		@ApiResponse(
+			responseCode = "403",
+			description = "크루 리더가 아닌데, 크루 리더의 권한을 행하려고 하는 경우",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = @ExampleObject(
+					name = "",
+					value = """
+						{
+							"resultCode": 403,
+							"code": "LEADER_PERMISSION_DENIED",
+							"message"; "CREW LEADER의 권한이 필요합니다."
+						}
+						"""
+				)
+			)
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = """
+				1. 사용자 식별자를 통해 사용자를 조회하지 못했을 때
+				2. 크루 식별자를 통해 크루를 조회하지 못했을 때
+				3. 닉네임을 통해 사용자를 조회하지 못했을 때
+				""",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "사용자 식별자를 통해 사용자를 조회하지 못했을 때",
+						value = """
+							{
+								"resultCode": 404,
+								"code": "MEMBER_NOT_FOUND",
+								"message"; "사용자를 찾을 수 없습니다."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "크루 식별자를 통해 크루를 조회하지 못했을 때",
+						value = """
+							{
+								"resultCode": 404,
+								"code": "CREW_NOT_FOUND",
+								"message"; "해당 CREW를 찾을 수 없습니다."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "닉네임을 통해 사용자를 조회하지 못했을 때",
+						value = """
+							{
+								"resultCode": 404,
+								"code": "MEMBER_NOT_FOUND",
+								"message"; "사용자를 찾을 수 없습니다."
+							}
+							"""
+					)
+				}
+			)
+		)
+	})
+	CommonResponse expelCrew(
+		@HereWeUser User user, @PathVariable Long crewId,
+		@RequestParam(name = "nickname") String nickname);
 }
 

--- a/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
+++ b/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
@@ -4,15 +4,18 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.genius.herewe.business.crew.dto.CrewCreateRequest;
+import com.genius.herewe.business.crew.dto.CrewExpelRequest;
 import com.genius.herewe.business.crew.dto.CrewMemberResponse;
 import com.genius.herewe.business.crew.dto.CrewModifyRequest;
 import com.genius.herewe.business.crew.dto.CrewPreviewResponse;
@@ -95,6 +98,16 @@ public class CrewController implements CrewApi {
 	@PostMapping("/invite/{token}")
 	public CommonResponse joinCrew(@PathVariable(name = "token") String inviteToken) {
 		invitationFacade.joinCrew(inviteToken);
+
+		return CommonResponse.ok();
+	}
+
+	@DeleteMapping("/{crewId}")
+	public CommonResponse expelCrew(
+		@HereWeUser User user, @PathVariable Long crewId,
+		@RequestParam(name = "nickname") String nickname) {
+
+		crewFacade.expelCrew(user.getId(), new CrewExpelRequest(crewId, nickname));
 
 		return CommonResponse.ok();
 	}

--- a/src/main/java/com/genius/herewe/business/crew/domain/Crew.java
+++ b/src/main/java/com/genius/herewe/business/crew/domain/Crew.java
@@ -96,6 +96,9 @@ public class Crew extends BaseTimeEntity implements FileHolder {
 	}
 
 	public void updateParticipantCount(int amount) {
+		if (this.participantCount != crewMembers.size()) {
+			this.participantCount = crewMembers.size();
+		}
 		if (amount < 0 && this.participantCount + amount < 0) {
 			return;
 		}

--- a/src/main/java/com/genius/herewe/business/crew/domain/Crew.java
+++ b/src/main/java/com/genius/herewe/business/crew/domain/Crew.java
@@ -94,4 +94,11 @@ public class Crew extends BaseTimeEntity implements FileHolder {
 		if (introduce != null)
 			this.introduce = introduce;
 	}
+
+	public void updateParticipantCount(int amount) {
+		if (amount < 0 && this.participantCount + amount < 0) {
+			return;
+		}
+		this.participantCount += amount;
+	}
 }

--- a/src/main/java/com/genius/herewe/business/crew/domain/CrewMember.java
+++ b/src/main/java/com/genius/herewe/business/crew/domain/CrewMember.java
@@ -59,6 +59,7 @@ public class CrewMember {
 			user.getCrewMembers().add(this);
 		}
 		if (!crew.getCrewMembers().contains(this)) {
+			crew.updateParticipantCount(1);
 			crew.getCrewMembers().add(this);
 		}
 	}

--- a/src/main/java/com/genius/herewe/business/crew/domain/CrewMember.java
+++ b/src/main/java/com/genius/herewe/business/crew/domain/CrewMember.java
@@ -59,7 +59,6 @@ public class CrewMember {
 			user.getCrewMembers().add(this);
 		}
 		if (!crew.getCrewMembers().contains(this)) {
-			crew.updateParticipantCount(1);
 			crew.getCrewMembers().add(this);
 		}
 	}

--- a/src/main/java/com/genius/herewe/business/crew/dto/CrewExpelRequest.java
+++ b/src/main/java/com/genius/herewe/business/crew/dto/CrewExpelRequest.java
@@ -1,0 +1,10 @@
+package com.genius.herewe.business.crew.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CrewExpelRequest(
+	Long crewId,
+	String targetName
+) {
+}

--- a/src/main/java/com/genius/herewe/business/crew/facade/CrewFacade.java
+++ b/src/main/java/com/genius/herewe/business/crew/facade/CrewFacade.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.genius.herewe.business.crew.dto.CrewCreateRequest;
+import com.genius.herewe.business.crew.dto.CrewExpelRequest;
 import com.genius.herewe.business.crew.dto.CrewMemberResponse;
 import com.genius.herewe.business.crew.dto.CrewModifyRequest;
 import com.genius.herewe.business.crew.dto.CrewPreviewResponse;
@@ -19,4 +20,6 @@ public interface CrewFacade {
 	CrewPreviewResponse createCrew(Long userId, CrewCreateRequest request);
 
 	CrewPreviewResponse modifyCrew(Long userId, Long crewId, CrewModifyRequest request);
+
+	void expelCrew(Long userId, CrewExpelRequest expelRequest);
 }

--- a/src/main/java/com/genius/herewe/business/crew/service/CrewMemberService.java
+++ b/src/main/java/com/genius/herewe/business/crew/service/CrewMemberService.java
@@ -45,4 +45,9 @@ public class CrewMemberService {
 	public Page<CrewPreviewResponse> findAllJoinCrews(Long userId, Pageable pageable) {
 		return queryRepository.findAllJoinCrews(userId, pageable);
 	}
+
+	@Transactional
+	public void delete(CrewMember crewMember) {
+		crewMemberRepository.delete(crewMember);
+	}
 }

--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 
 	CREW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 CREW를 찾을 수 없습니다."),
 	LEADER_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "CREW LEADER의 권한이 필요합니다."),
+	LEADER_CANNOT_EXPEL(HttpStatus.BAD_REQUEST, "CREW LEADER는 CREW에서 탈퇴할 수 없습니다."),
 
 	CREW_JOIN_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 크루에 대한 참여 정보가 없습니다."),
 	ALREADY_JOINED_CREW(HttpStatus.BAD_REQUEST, "이미 참여한 크루입니다."),

--- a/src/main/java/com/genius/herewe/core/user/controller/UserApi.java
+++ b/src/main/java/com/genius/herewe/core/user/controller/UserApi.java
@@ -8,12 +8,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.genius.herewe.infra.file.dto.FileResponse;
-import com.genius.herewe.core.user.dto.SignupRequest;
-import com.genius.herewe.core.user.dto.SignupResponse;
 import com.genius.herewe.core.global.response.CommonResponse;
 import com.genius.herewe.core.global.response.ExceptionResponse;
 import com.genius.herewe.core.global.response.SingleResponse;
+import com.genius.herewe.core.user.dto.SignupRequest;
+import com.genius.herewe.core.user.dto.SignupResponse;
+import com.genius.herewe.infra.file.dto.FileResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/44-expel-crew` -> `main`

</br>

### 🛠️ 변경 사항
> 크루 리더의 권한 중 하나인, 크루에서 특정 크루원 내보내기 기능을 개발합니다. 

#### ✅ 작업 상세 내용
- [x] 크루 내보내기 API `DELETE /api/crew/{crewId}?nickname={nickname}`
- [x] Crew 엔티티에 참여 인원 수를 갱신하는 비지니스 코드 추가
- [x] 크루 내보내기 테스트 코드 작성(단위 테스트)
- [x] CrewApi 인터페이스에 `expelCrew()` 메서드 및 swagger 어노테이션 추가

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/6539eba4-0a8f-4a60-88cf-5f0a48eeda34)

</br>

### 📚 연관된 이슈
#44 

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
