### PR TITLE
[REFACTOR] 회원가입 프로필 조회/수정 API 스펙 변경

### DIFF
--- a/src/main/java/com/genius/herewe/core/security/service/token/RegistrationTokenService.java
+++ b/src/main/java/com/genius/herewe/core/security/service/token/RegistrationTokenService.java
@@ -35,10 +35,7 @@ public class RegistrationTokenService {
 		if (registrationToken.isEmpty()) {
 			throw new BusinessException(REGISTRATION_TOKEN_NOT_FOUND);
 		}
-		Long userId = registrationToken.get().getUserId();
-		deleteToken(token);
-
-		return userId;
+		return registrationToken.get().getUserId();
 	}
 
 	public void deleteToken(String token) {

--- a/src/main/java/com/genius/herewe/core/user/controller/UserApi.java
+++ b/src/main/java/com/genius/herewe/core/user/controller/UserApi.java
@@ -2,7 +2,6 @@ package com.genius.herewe.core.user.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -138,7 +137,7 @@ public interface UserApi {
 	})
 	@GetMapping("/auth/profile/{id}")
 	SingleResponse<FileResponse> getProfile(
-		@Parameter(description = "찾고자하는 객체의 식별자(PK)") @PathVariable Long id);
+		@Parameter(description = "사용자의 회원가입 토큰") @RequestParam("token") String token);
 
 	@Operation(summary = "사용자 프로필 갱신", description = "회원가입 과정에서 사용자의 프로필 갱신")
 	@ApiResponses({
@@ -183,7 +182,7 @@ public interface UserApi {
 	})
 	@PatchMapping("/auth/profile/{id}")
 	SingleResponse<FileResponse> updateProfile(
-		@Parameter(description = "찾고자하는 객체의 식별자(PK)") @PathVariable Long id,
+		@Parameter(description = "사용자의 회원가입 토큰") @RequestParam("token") String token,
 		@Parameter(description = "저장하고자하는 파일을 form-data의 files 항목으로 전달") @RequestParam(value = "files") MultipartFile multipartFile
 	);
 }

--- a/src/main/java/com/genius/herewe/core/user/controller/UserController.java
+++ b/src/main/java/com/genius/herewe/core/user/controller/UserController.java
@@ -3,7 +3,6 @@ package com.genius.herewe.core.user.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,17 +10,18 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.genius.herewe.core.global.response.CommonResponse;
+import com.genius.herewe.core.global.response.SingleResponse;
+import com.genius.herewe.core.security.service.token.RegistrationTokenService;
+import com.genius.herewe.core.user.dto.SignupRequest;
+import com.genius.herewe.core.user.dto.SignupResponse;
+import com.genius.herewe.core.user.facade.UserFacade;
 import com.genius.herewe.infra.file.domain.FileHolder;
 import com.genius.herewe.infra.file.domain.FileType;
 import com.genius.herewe.infra.file.domain.Files;
 import com.genius.herewe.infra.file.dto.FileResponse;
 import com.genius.herewe.infra.file.service.FileHolderFinder;
 import com.genius.herewe.infra.file.service.FilesManager;
-import com.genius.herewe.core.user.dto.SignupRequest;
-import com.genius.herewe.core.user.dto.SignupResponse;
-import com.genius.herewe.core.user.facade.UserFacade;
-import com.genius.herewe.core.global.response.CommonResponse;
-import com.genius.herewe.core.global.response.SingleResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api")
 public class UserController implements UserApi {
 	private final UserFacade userFacade;
+	private final RegistrationTokenService registrationTokenService;
 	private final FileHolderFinder holderFinder;
 	private final FilesManager filesManager;
 
@@ -45,20 +46,22 @@ public class UserController implements UserApi {
 		return new SingleResponse<>(HttpStatus.CREATED, signupResponse);
 	}
 
-	@GetMapping("/auth/profile/{id}")
-	public SingleResponse<FileResponse> getProfile(@PathVariable Long id) {
-		FileHolder fileHolder = holderFinder.find(id, FileType.PROFILE);
+	@GetMapping("/auth/profile")
+	public SingleResponse<FileResponse> getProfile(@RequestParam("token") String token) {
+		Long userId = registrationTokenService.getUserIdFromToken(token);
+		FileHolder fileHolder = holderFinder.find(userId, FileType.PROFILE);
 		FileResponse fileResponse = filesManager.convertToFileResponse(fileHolder.getFiles());
 
 		return new SingleResponse<>(HttpStatus.OK, fileResponse);
 	}
 
-	@PatchMapping("/auth/profile/{id}")
+	@PatchMapping("/auth/profile")
 	public SingleResponse<FileResponse> updateProfile(
-		@PathVariable Long id,
+		@RequestParam("token") String token,
 		@RequestParam(value = "files") MultipartFile multipartFile
 	) {
-		FileHolder fileHolder = holderFinder.find(id, FileType.PROFILE);
+		Long userId = registrationTokenService.getUserIdFromToken(token);
+		FileHolder fileHolder = holderFinder.find(userId, FileType.PROFILE);
 		Files files = filesManager.updateFile(fileHolder.getFiles(), multipartFile);
 		FileResponse fileResponse = filesManager.convertToFileResponse(files);
 

--- a/src/main/java/com/genius/herewe/core/user/facade/DefaultUserFacade.java
+++ b/src/main/java/com/genius/herewe/core/user/facade/DefaultUserFacade.java
@@ -45,6 +45,7 @@ public class DefaultUserFacade implements UserFacade {
 	@Transactional
 	public SignupResponse signup(SignupRequest signupRequest) {
 		Long userId = registrationTokenService.getUserIdFromToken(signupRequest.token());
+		registrationTokenService.deleteToken(signupRequest.token());
 		User user = userService.findById(userId);
 
 		String nickname = signupRequest.nickname();


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`refactor/48-profile-api-spec` -> `main`

</br>

### 🛠️ 변경 사항
> 회원가입 프로필 조회/수정 API에서 path variable로 userId를 받아 진행했던 방식에서, 회원가입 UUID token을 받아 진행하도록 변경합니다.

#### ✅ 작업 상세 내용
- [x] RegistrationTokenService 메서드 분리
    - [x] `getUserIdFromToken()`에 `delete()` 메서드 분리
    - [x] UserFacade의 `signup()`에서 `delete()`를 별도로 호출하도록 변경
- [x] 회원가입 프로필 조회/수정 API 요청 시 토큰을 전달받도록 변경 (토큰은 회원가입이 완료되면 삭제됨)
    - [x] `/api/auth/profile{id}` → `/api/auth/profile?token={token}`로 변경


</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/3b8cf5b5-ce2f-4bf4-bcf6-327b6185711c)

</br>

### 📚 연관된 이슈
#48 

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
