### PR TITLE
[REFACTOR] JWT 재발급 조건 변경

### DIFF
--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -30,7 +30,7 @@ public enum ErrorCode {
 	JWT_NOT_FOUND_IN_HEADER(HttpStatus.UNAUTHORIZED, "Header에서 JWT를 찾을 수 없습니다."),
 	JWT_NOT_FOUND_IN_COOKIE(HttpStatus.UNAUTHORIZED, "Cookie에서 JWT를 찾을 수 없습니다."),
 	REFRESH_NOT_FOUND_IN_DB(HttpStatus.NOT_FOUND, "DB에서 사용자의 Refresh token 정보를 찾을 수 없습니다."),
-	TOKEN_HIJACKED(HttpStatus.UNAUTHORIZED, "토큰 탈취가 감지되었습니다."),
+	TOKEN_HIJACKED(HttpStatus.UNAUTHORIZED, "토큰 탈취가 감지되었습니다. 다시 로그인해주세요."),
 
 	REGISTRATION_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "회원가입 토큰을 찾을 수 없습니다."),
 

--- a/src/main/java/com/genius/herewe/core/security/constants/JwtStatus.java
+++ b/src/main/java/com/genius/herewe/core/security/constants/JwtStatus.java
@@ -3,5 +3,6 @@ package com.genius.herewe.core.security.constants;
 public enum JwtStatus {
 	VALID,
 	EXPIRED,
-	INVALID
+	INVALID,
+	NEED_CHECK_RT
 }

--- a/src/main/java/com/genius/herewe/core/security/service/DefaultJwtFacade.java
+++ b/src/main/java/com/genius/herewe/core/security/service/DefaultJwtFacade.java
@@ -133,7 +133,9 @@ public class DefaultJwtFacade implements JwtFacade {
 	@Override
 	public String resolveAccessToken(HttpServletRequest request) {
 		String bearerHeader = request.getHeader(ACCESS_HEADER.getValue());
-		if (bearerHeader == null || bearerHeader.isBlank()) {
+		if (bearerHeader == null || bearerHeader.isEmpty()) {
+			return "";
+		} else if (!bearerHeader.startsWith(ACCESS_PREFIX.getValue())) {
 			throw new BusinessException(JWT_NOT_FOUND_IN_HEADER);
 		}
 		return bearerHeader.trim().substring(7);
@@ -155,6 +157,9 @@ public class DefaultJwtFacade implements JwtFacade {
 
 	@Override
 	public JwtStatus verifyAccessToken(String accessToken) {
+		if (accessToken.isEmpty()) {
+			return JwtStatus.NEED_CHECK_RT;
+		}
 		try {
 			Jwts.parserBuilder()
 				.setSigningKey(ACCESS_SECRET_KEY)


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`refactor/50-jwt-reissue-condition` -> `main`

</br>

### 🛠️ 변경 사항
> JWT를 재발급하는 조건을 변경합니다.
> Header로 전달한 Access-token을 프론트(클라이언트)에서 XSS 공격 이슈로 인해 LocalStorage에 저장하지 않도록 변경되었습니다.
> 이로 인해 JWT 재발급 조건을 변경합니다.
> JWT 재발급 조건을 "access-token은 만료 상태 & refresh-token 유효 상태" 에서 "refresh-token 유효 상태"일 때로 변경

#### ✅ 작업 상세 내용
- [x] JWT재발급 조건을 "AT 없음 & RT 유효"로 변경하면서 resolveAccessToken에 분기 추가
    - [x] verifyAccessToken에서 전달받은 토큰이 빈 문자열인 경우 NEED_CHECK_RT를 반환하도록 변경
- [x] ErrorCode의 메세지 변경
- [x] 재발급 변경 로직이 변경되면서 테스트 코드도 수정
    - [x] resolveAccessToken, verifyAccessToken에 대해 테스트 코드 수정

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/1a47a3b2-c304-4132-84ca-6412fed5a243)


</br>

### 📚 연관된 이슈
#50

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
