### PR TITLE
[FIX] 파일 등록 시, 크루/모먼트 타입을 인식하지 못하는 버그 픽스

### DIFF
--- a/src/main/java/com/genius/herewe/business/crew/controller/CrewApi.java
+++ b/src/main/java/com/genius/herewe/business/crew/controller/CrewApi.java
@@ -187,6 +187,31 @@ public interface CrewApi {
 		@PathVariable Long crewId,
 		@RequestBody CrewModifyRequest crewModifyRequest);
 
+	@Operation(summary = "크루 삭제", description = "crewId(식별자)를 통해 특정 크루 삭제")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "크루 삭제 성공"
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = "crewId(PK - 식별자)를 통해 해당 크루를 찾지 못한 경우",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = @ExampleObject(
+					value = """
+						{
+						    "resultCode": 404,
+						    "code": "CREW_NOT_FOUND",
+						    "message": "해당 CREW를 찾을 수 없습니다."
+						}
+						"""
+				)
+			)
+		)
+	})
+	CommonResponse deleteCrew(@PathVariable Long crewId);
+
 	@Operation(summary = "크루 초대", description = "특정 사용자에게 크루 초대 요청 (초대 링크가 담긴 메일 전송)")
 	@ApiResponses({
 		@ApiResponse(

--- a/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
+++ b/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
@@ -86,6 +86,12 @@ public class CrewController implements CrewApi {
 		return new SingleResponse<>(HttpStatus.OK, response);
 	}
 
+	@DeleteMapping("/{crewId}")
+	public CommonResponse deleteCrew(@PathVariable Long crewId) {
+		crewFacade.deleteCrew(crewId);
+		return CommonResponse.ok();
+	}
+
 	@PostMapping("/invite")
 	public CommonResponse inviteCrew(
 		@Valid @RequestBody InvitationRequest invitationRequest) {
@@ -102,7 +108,7 @@ public class CrewController implements CrewApi {
 		return CommonResponse.ok();
 	}
 
-	@DeleteMapping("/{crewId}")
+	@DeleteMapping("/{crewId}/members")
 	public CommonResponse expelCrew(
 		@HereWeUser User user, @PathVariable Long crewId,
 		@RequestParam(name = "nickname") String nickname) {

--- a/src/main/java/com/genius/herewe/business/crew/facade/CrewFacade.java
+++ b/src/main/java/com/genius/herewe/business/crew/facade/CrewFacade.java
@@ -21,5 +21,7 @@ public interface CrewFacade {
 
 	CrewPreviewResponse modifyCrew(Long userId, Long crewId, CrewModifyRequest request);
 
+	void deleteCrew(Long crewId);
+
 	void expelCrew(Long userId, CrewExpelRequest expelRequest);
 }

--- a/src/main/java/com/genius/herewe/business/crew/facade/DefaultCrewFacade.java
+++ b/src/main/java/com/genius/herewe/business/crew/facade/DefaultCrewFacade.java
@@ -21,6 +21,8 @@ import com.genius.herewe.business.crew.service.CrewService;
 import com.genius.herewe.core.global.exception.BusinessException;
 import com.genius.herewe.core.user.domain.User;
 import com.genius.herewe.core.user.service.UserService;
+import com.genius.herewe.infra.file.dto.FileDTO;
+import com.genius.herewe.infra.file.service.FilesStorage;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,6 +33,7 @@ public class DefaultCrewFacade implements CrewFacade {
 	private final UserService userService;
 	private final CrewService crewService;
 	private final CrewMemberService crewMemberService;
+	private final FilesStorage filesStorage;
 
 	@Override
 	public Page<CrewPreviewResponse> inquiryMyCrews(Long userId, Pageable pageable) {
@@ -86,6 +89,16 @@ public class DefaultCrewFacade implements CrewFacade {
 
 		crew.modify(request.name(), request.introduce());
 		return CrewPreviewResponse.create(crew);
+	}
+
+	@Override
+	@Transactional
+	public void deleteCrew(Long crewId) {
+		Crew crew = crewService.findById(crewId);
+		if (crew.getFiles() != null) {
+			filesStorage.delete(FileDTO.create(crew.getFiles()));
+		}
+		crewService.delete(crew);
 	}
 
 	@Override

--- a/src/main/java/com/genius/herewe/business/crew/service/CrewService.java
+++ b/src/main/java/com/genius/herewe/business/crew/service/CrewService.java
@@ -25,4 +25,9 @@ public class CrewService {
 	public Crew save(Crew crew) {
 		return crewRepository.save(crew);
 	}
+
+	@Transactional
+	public void delete(Crew crew) {
+		crewRepository.delete(crew);
+	}
 }

--- a/src/main/java/com/genius/herewe/business/moment/repository/MomentRepository.java
+++ b/src/main/java/com/genius/herewe/business/moment/repository/MomentRepository.java
@@ -1,0 +1,8 @@
+package com.genius.herewe.business.moment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.genius.herewe.business.moment.domain.Moment;
+
+public interface MomentRepository extends JpaRepository<Moment, Long> {
+}

--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -30,6 +30,8 @@ public enum ErrorCode {
 	INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "크루 초대 정보를 찾을 수 없습니다. 초대 정보를 다시 확인해주세요."),
 	INVITATION_EXPIRED(HttpStatus.BAD_REQUEST, "크루 초대가 만료되었습니다."),
 
+	MOMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 MOMENT를 찾을 수 없습니다."),
+
 	UNAUTHORIZED_ISSUE(HttpStatus.UNAUTHORIZED, "회원가입이 되어 있지 않은 사용자의 경우 JWT를 발급할 수 없습니다."),
 	JWT_NOT_VALID(HttpStatus.UNAUTHORIZED, "JWT가 유효하지 않습니다."),
 	JWT_NOT_FOUND_IN_HEADER(HttpStatus.UNAUTHORIZED, "Header에서 JWT를 찾을 수 없습니다."),

--- a/src/main/java/com/genius/herewe/infra/file/service/FileHolderFinder.java
+++ b/src/main/java/com/genius/herewe/infra/file/service/FileHolderFinder.java
@@ -4,6 +4,8 @@ import static com.genius.herewe.core.global.exception.ErrorCode.*;
 
 import org.springframework.stereotype.Service;
 
+import com.genius.herewe.business.crew.repository.CrewRepository;
+import com.genius.herewe.business.moment.repository.MomentRepository;
 import com.genius.herewe.core.global.exception.BusinessException;
 import com.genius.herewe.core.user.repository.UserRepository;
 import com.genius.herewe.infra.file.domain.FileHolder;
@@ -15,12 +17,22 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FileHolderFinder {
 	private final UserRepository userRepository;
+	private final CrewRepository crewRepository;
+	private final MomentRepository momentRepository;
 
 	public FileHolder find(Long id, FileType fileType) {
 		switch (fileType) {
 			case PROFILE -> {
 				return userRepository.findById(id)
 					.orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
+			}
+			case CREW -> {
+				return crewRepository.findById(id)
+					.orElseThrow(() -> new BusinessException(CREW_NOT_FOUND));
+			}
+			case MOMENT -> {
+				return momentRepository.findById(id)
+					.orElseThrow(() -> new BusinessException(MOMENT_NOT_FOUND));
 			}
 		}
 		throw new BusinessException(NOT_SUPPORTED_IMAGE_TYPE);

--- a/src/main/java/com/genius/herewe/infra/file/service/FilesManager.java
+++ b/src/main/java/com/genius/herewe/infra/file/service/FilesManager.java
@@ -61,6 +61,10 @@ public class FilesManager {
 		FileEnv fileEnv = filesStorage.getFileEnvironment();
 		FileDTO fileDTO = filesStorage.upload(multipartFile, fileEnv, fileType);
 
+		if (fileHolder.getFiles().getId() != null) {
+			filesStorage.delete(FileDTO.create(fileHolder.getFiles()));
+		}
+
 		Files files = Files.builder()
 			.environment(fileEnv)
 			.type(fileType)

--- a/src/test/java/com/genius/herewe/business/crew/facade/CrewFacadeTest.java
+++ b/src/test/java/com/genius/herewe/business/crew/facade/CrewFacadeTest.java
@@ -29,6 +29,7 @@ import com.genius.herewe.core.global.exception.BusinessException;
 import com.genius.herewe.core.user.domain.User;
 import com.genius.herewe.core.user.fixture.UserFixture;
 import com.genius.herewe.core.user.service.UserService;
+import com.genius.herewe.infra.file.service.FilesStorage;
 
 @ExtendWith(MockitoExtension.class)
 class CrewFacadeTest {
@@ -39,10 +40,12 @@ class CrewFacadeTest {
 	private CrewService crewService;
 	@Mock
 	private CrewMemberService crewMemberService;
+	@Mock
+	private FilesStorage filesStorage;
 
 	@BeforeEach
 	void init() {
-		crewFacade = new DefaultCrewFacade(userService, crewService, crewMemberService);
+		crewFacade = new DefaultCrewFacade(userService, crewService, crewMemberService, filesStorage);
 	}
 
 	@Nested
@@ -238,6 +241,27 @@ class CrewFacadeTest {
 				assertThat(crewResponse.leaderName()).isEqualTo(crew.getLeaderName());
 				assertThat(crewResponse.role()).isEqualTo(crewMember.getRole());
 				assertThat(crewResponse.participantCount()).isEqualTo(crew.getParticipantCount());
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("크루 삭제 시")
+	class Context_delete_crew {
+		@Nested
+		@DisplayName("크루의 식별자(PK)를 전달했을 때")
+		class Describe_pass_crew_pk {
+			@Test
+			@DisplayName("크루의 식별자를 통해 크루를 찾지 못하면 CREW_NOT_FOUND 예외가 발생한다.")
+			public void it_throws_CREW_NOT_FOUND_exception() {
+				//given
+				Long fakeCrewId = 999L;
+				given(crewService.findById(fakeCrewId)).willThrow(new BusinessException(CREW_NOT_FOUND));
+
+				//when & then
+				assertThatThrownBy(() -> crewFacade.deleteCrew(fakeCrewId))
+					.isInstanceOf(BusinessException.class)
+					.hasMessageContaining(CREW_NOT_FOUND.getMessage());
 			}
 		}
 	}


### PR DESCRIPTION
### PR 타입
□ 기능 추가
□ 기능 삭제
□ 리팩터링
☑ 버그 리포트
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`fix/54-file-recognition` -> `main`

</br>

### 🛠️ 변경 사항
> 크루 생성 과정에서 크루의 썸네일(파일) 또한 생성을 시도하는데, 이 때 `message: 파일을 받을 수 있는 종류가 아닙니다. profile, crew, moment 중 하나를 입력해주세요.` 메세지가 발생하는 버그 픽스
> `FileHolderFinder`의 `find()` 메서드에서 PROFILE 타입만 검사를 진행하고 있었음

#### ✅ 작업 상세 내용
- [x] FileHolderFinder에서 FileType을 찾을 때 PROFILE 외에 CREW, MOMENT 추가
- [x] MomentRepository 인터페이스 작성
- [x] ErrorCode에 Moment 엔티티 찾지 못했을 때 추가
- [x] 파일 업로드 메서드에, 파일이 기존에 존재하는 경우 해당 저장소에서 파일을 삭제하는 로직 추가
- [x] crew 삭제 API 구현 (DELETE /api/crew/{crewId})
    - [x] 크루 내보내기 API endpoint 변경 (DELETE /api/crew/{crewId}/members?nickname={nickname})
    - [x] crew 삭제 시 files 엔티티도 함께 삭제되며, 저장소에 저장된 파일도 같이 삭제 처리
    - [x] CrewApi에 swagger 정보 추가
    - [x] 테스트 코드 추가

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/9ab2594e-ce97-4948-a268-6ebedcd05327)


</br>

### 📚 연관된 이슈
#54

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
