### PR TITLE
[FIX] 회원가입 시 닉네임 길이 관련 예외가 발생하지 않는 버그 수정

### DIFF
--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
 	ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 가입한 사용자입니다."),
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 	NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다. 닉네임은 중복될 수 없습니다."),
+	INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임은 2한글, 영문자, 숫자만 가능하며 2~20자여야 합니다."),
 
 	CREW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 CREW를 찾을 수 없습니다."),
 	LEADER_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "CREW LEADER의 권한이 필요합니다."),

--- a/src/main/java/com/genius/herewe/core/user/controller/UserController.java
+++ b/src/main/java/com/genius/herewe/core/user/controller/UserController.java
@@ -36,7 +36,7 @@ public class UserController implements UserApi {
 
 	@GetMapping("/auth/check-nickname")
 	public CommonResponse checkNicknameDuplicated(@RequestParam(value = "nickname") String nickname) {
-		userFacade.isNicknameDuplicated(nickname);
+		userFacade.validateNickname(nickname);
 		return CommonResponse.ok();
 	}
 

--- a/src/main/java/com/genius/herewe/core/user/facade/UserFacade.java
+++ b/src/main/java/com/genius/herewe/core/user/facade/UserFacade.java
@@ -8,7 +8,7 @@ import com.genius.herewe.core.user.dto.SignupResponse;
 public interface UserFacade {
 	User findUser(Long userId);
 
-	void isNicknameDuplicated(String nickname);
+	void validateNickname(String nickname);
 
 	SignupResponse signup(SignupRequest signupRequest);
 


### PR DESCRIPTION
### PR 타입
□ 기능 추가
□ 기능 삭제
□ 리팩터링
☑ 버그 리포트
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`fix/52-nickname-constaints` -> `main`

</br>

### 🛠️ 변경 사항
> `UserFacade`에 닉네임의 유효성을 검사하는 로직을 추가합니다.

#### ✅ 작업 상세 내용
- [x] `UserFacade`에 닉네임 유효성 검사 로직 추가 (2~20자 제한, 한글/영문자/숫자만 허용)
- [x] `UserFacadeTest`에 닉네임 유효성 검사 관련 테스트 코드 추가 

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/af22c8c4-a5d7-48d7-b87b-98698e5ff347)

</br>

### 📚 연관된 이슈
#54 

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
