### PR TITLE
[DOCS] 모먼트 생성/수정 API에 swagger 정보 추가

### DIFF
--- a/src/main/java/com/genius/herewe/business/location/service/LocationService.java
+++ b/src/main/java/com/genius/herewe/business/location/service/LocationService.java
@@ -1,6 +1,6 @@
 package com.genius.herewe.business.location.service;
 
-import static com.genius.herewe.core.global.exception.ErrorCode.*;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.genius.herewe.business.location.domain.Location;
 import com.genius.herewe.business.location.repository.LocationRepository;
 import com.genius.herewe.business.location.search.dto.Place;
-import com.genius.herewe.core.global.exception.BusinessException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,8 +23,7 @@ public class LocationService {
 		return locationRepository.save(location);
 	}
 
-	public Location findMeetLocation(Long momentId) {
-		return locationRepository.findByLocationIndex(momentId, 1)
-			.orElseThrow(() -> new BusinessException(NEED_MEET_PLACE));
+	public Optional<Location> findMeetLocation(Long momentId) {
+		return locationRepository.findByLocationIndex(momentId, 1);
 	}
 }

--- a/src/main/java/com/genius/herewe/business/moment/controller/MomentApi.java
+++ b/src/main/java/com/genius/herewe/business/moment/controller/MomentApi.java
@@ -6,13 +6,141 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import com.genius.herewe.business.moment.dto.MomentRequest;
 import com.genius.herewe.business.moment.dto.MomentResponse;
+import com.genius.herewe.core.global.response.ExceptionResponse;
 import com.genius.herewe.core.global.response.SingleResponse;
 import com.genius.herewe.core.security.annotation.HereWeUser;
 import com.genius.herewe.core.user.domain.User;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
 public interface MomentApi {
+	@Operation(summary = "모먼트 생성", description = "특정 크루에 모먼트 생성")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "201",
+			description = "모먼트 생성 성공"
+		),
+		@ApiResponse(
+			responseCode = "400",
+			description = """
+				1. 필수 입력 항목 누락 시
+				2. 크루 참여 인원이 2명 미만일 때
+				3. 참여 일자(meetAt) & 마감일자(closedAt)이 요청 일자 이전일 때 / 참여 일자가 마감 일자 이전일 때
+				""",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "필수 입력 항목(크루 생성의 경우 모든 항목) 누락 시",
+						value = """
+							{
+								"resultCode": "400",
+								"code": "REQUIRED_FIELD_MISSING",
+								"message": "해당 항목은 필수 항목입니다. 입력 값을 확인해주세요."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "크루 참여 인원이 2명 미만일 때",
+						value = """
+							{
+								"resultCode": "400",
+								"code": "INVALID_MOMENT_CAPACITY",
+								"message": "MOMENT의 최대 참여 가능 인원은 2명 이상이어야 합니다."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "참여 일자(meetAt) & 마감일자(closedAt)이 요청 일자 이전일 때 / 참여 일자가 마감 일자 이전일 때",
+						value = """
+							{
+								"resultCode": "400",
+								"code": "INVALID_MOMENT_DATE",
+								"message": "만남일자(meetAt)/마감일자(closedAt)는 오늘보다 나중이어야 하며, 만남일자가 마감일자보다 더 이후여야 합니다."
+							}
+							"""
+					)
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = """
+				1. userId를 통해 User 엔티티를 찾을 수 없을 때
+				2. crewId를 통해 Crew 엔티티를 찾을 수 없을 때
+				""",
+			content = @Content(
+				examples = {
+					@ExampleObject(
+						name = "userId를 통해 User 엔티티를 찾을 수 없을 때",
+						value = """
+							{
+								"resultCode": "404",
+								"code": "MEMBER_NOT_FOUND",
+								"message": "사용자를 찾을 수 없습니다."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "crewId를 통해 Crew 엔티티를 찾을 수 없을 때",
+						value = """
+							{
+								"resultCode": "404",
+								"code": "CREW_NOT_FOUND",
+								"message": "해당 CREW를 찾을 수 없습니다."
+							}
+							"""
+					)
+				}
+			)
+		)
+	})
 	SingleResponse<MomentResponse> createMoment(@HereWeUser User user, @RequestParam(name = "crewId") Long crewId,
 		@RequestBody MomentRequest momentRequest);
 
+	@Operation(summary = "모먼트 수정", description = "모먼트의 정보 수정")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "모먼트 수정 성공"
+		),
+		@ApiResponse(
+			responseCode = "400",
+			description = """
+				1. 크루 참여 인원이 2명 미만일 때
+				2. 참여 일자(meetAt) & 마감일자(closedAt)이 요청 일자 이전일 때 / 참여 일자가 마감 일자 이전일 때
+				""",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "크루 참여 인원이 2명 미만일 때",
+						value = """
+							{
+								"resultCode": "400",
+								"code": "INVALID_MOMENT_CAPACITY",
+								"message": "MOMENT의 최대 참여 가능 인원은 2명 이상이어야 합니다."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "참여 일자(meetAt) & 마감일자(closedAt)이 요청 일자 이전일 때 / 참여 일자가 마감 일자 이전일 때",
+						value = """
+							{
+								"resultCode": "400",
+								"code": "INVALID_MOMENT_DATE",
+								"message": "만남일자(meetAt)/마감일자(closedAt)는 오늘보다 나중이어야 하며, 만남일자가 마감일자보다 더 이후여야 합니다."
+							}
+							"""
+					)
+				}
+			)
+		)
+	})
 	SingleResponse<MomentResponse> modifyMoment(@PathVariable Long momentId, @RequestBody MomentRequest momentRequest);
 }

--- a/src/main/java/com/genius/herewe/business/moment/dto/MomentResponse.java
+++ b/src/main/java/com/genius/herewe/business/moment/dto/MomentResponse.java
@@ -4,15 +4,23 @@ import java.time.LocalDateTime;
 
 import com.genius.herewe.business.moment.domain.Moment;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "모먼트 미리보기 응답 객체")
 public record MomentResponse(
+	@Schema(description = "모먼트 식별자(PK)")
 	Long momentId,
+	@Schema(description = "사용자의 모먼트 참여 여부")
 	Boolean isJoined,
+	@Schema(description = "모먼트 이름")
 	String name,
+	@Schema(description = "현재 모먼트 참여 인원")
 	int participantCount,
+	@Schema(description = "모먼트 최대 참여 인원")
 	int capacity,
+	@Schema(description = "모먼트 참여 마감 일자")
 	LocalDateTime closedAt
 ) {
 

--- a/src/main/java/com/genius/herewe/business/moment/facade/DefaultMomentFacade.java
+++ b/src/main/java/com/genius/herewe/business/moment/facade/DefaultMomentFacade.java
@@ -79,8 +79,12 @@ public class DefaultMomentFacade implements MomentFacade {
 		moment.updateClosedAt(closedAt);
 
 		Optional.ofNullable(momentRequest.place()).ifPresent(place -> {
-			Location meetLocation = locationService.findMeetLocation(momentId);
-			meetLocation.update(place);
+			locationService.findMeetLocation(momentId)
+				.ifPresentOrElse(val -> val.update(place),
+					() -> {
+						Location fromPlace = Location.createFromPlace(place, 1);
+						fromPlace.addMoment(moment);
+					});
 		});
 
 		return MomentResponse.createJoined(moment, true);


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`docs/65-add-swagger-info-moment-api` -> `main`

</br>

### 🛠️ 변경 사항
> 모먼트 생성/수정 API에 swagger 정보를 추가합니다.

#### ✅ 작업 상세 내용
- [x] MomentController, MomentResponse에 swagger 정보 추가
- [x] 모먼트 수정 시 만남 장소 정보가 존재하지 않을 때, 수정 DTO를 통해 받은 정보를 바탕으로 엔티티를 생성하도록 변경

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/68d14ecb-6452-434e-8d48-e5e87525593c)

</br>

### 📚 연관된 이슈
#65

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
