### PR TITLE
[FEAT] 만남 장소 등록 API 개발

### DIFF
--- a/src/main/java/com/genius/herewe/business/location/LocationRequest.java
+++ b/src/main/java/com/genius/herewe/business/location/LocationRequest.java
@@ -1,0 +1,14 @@
+package com.genius.herewe.business.location;
+
+import com.genius.herewe.business.location.search.dto.Place;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "추가 할 장소 DTO")
+public record LocationRequest(
+	@Schema(description = "장소 정보")
+	Place place,
+	@Schema(description = "추가하는 장소가 부여받을 인덱스 번호")
+	int locationIndex
+) {
+}

--- a/src/main/java/com/genius/herewe/business/location/controller/LocationApi.java
+++ b/src/main/java/com/genius/herewe/business/location/controller/LocationApi.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
-public interface LocalApi {
+public interface LocationApi {
 	@Operation(summary = "키워드를 통한 장소 검색", description = "Kakao Map API를 이용하여 키워드 검색 결과를 반환합니다.")
 	@ApiResponses({
 		@ApiResponse(

--- a/src/main/java/com/genius/herewe/business/location/controller/LocationApi.java
+++ b/src/main/java/com/genius/herewe/business/location/controller/LocationApi.java
@@ -1,13 +1,22 @@
 package com.genius.herewe.business.location.controller;
 
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.genius.herewe.business.location.LocationRequest;
 import com.genius.herewe.business.location.search.dto.Place;
+import com.genius.herewe.core.global.response.ExceptionResponse;
+import com.genius.herewe.core.global.response.SingleResponse;
 import com.genius.herewe.core.global.response.SlicingResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 
 public interface LocationApi {
 	@Operation(summary = "키워드를 통한 장소 검색", description = "Kakao Map API를 이용하여 키워드 검색 결과를 반환합니다.")
@@ -20,4 +29,64 @@ public interface LocationApi {
 	SlicingResponse<Place> search(@RequestParam("keyword") String keyword,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size);
+
+	@Operation(summary = "장소 등록", description = "검색한 장소를 등록합니다.")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "장소 등록 성공"
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = "momentId(식별자)를 통해 모먼트 엔티티를 찾지 못했을 때",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "momentId(식별자)를 통해 모먼트 엔티티를 찾지 못했을 때",
+						description = """
+							{
+								"resultCode": "404",
+								"code": "MOMENT_NOT_FOUND",
+								"message": "해당 MOMENT를 찾을 수 없습니다."
+							}
+							"""
+					)
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "409",
+			description = """
+				1. 동시성 문제로 인해 예외 발생한 경우
+				2. 해당 인덱스로 이미 장소가 등록되어 있는 경우
+				""",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "1. 동시성 문제로 인해 예외 발생한 경우",
+						description = """
+							{
+								"resultCode": "409",
+								"code": "CONCURRENT_MODIFICATION_EXCEPTION",
+								"message": "이 데이터는 다른 사용자에 의해 수정되었습니다. 다시 시도해주세요."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "2. 해당 인덱스로 이미 장소가 등록되어 있는 경우",
+						description = """
+							{
+								"resultCode": "409",
+								"code": "LOCATION_ALREADY_EXISTS",
+								"message": "해당 순서의 장소가 이미 추가되었습니다. 잠시 후 다시 시도해주세요."
+							}
+							"""
+					)
+				}
+			)
+		)
+	})
+	SingleResponse<Place> addPlace(@PathVariable Long momentId, @Valid @RequestBody LocationRequest locationRequest);
 }

--- a/src/main/java/com/genius/herewe/business/location/controller/LocationController.java
+++ b/src/main/java/com/genius/herewe/business/location/controller/LocationController.java
@@ -3,21 +3,29 @@ package com.genius.herewe.business.location.controller;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.genius.herewe.business.location.LocationRequest;
+import com.genius.herewe.business.location.facade.LocationFacade;
 import com.genius.herewe.business.location.search.client.KakaoSearchClient;
 import com.genius.herewe.business.location.search.dto.Place;
+import com.genius.herewe.core.global.response.SingleResponse;
 import com.genius.herewe.core.global.response.SlicingResponse;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
-public class LocalController implements LocalApi {
+public class LocationController implements LocationApi {
 	private final KakaoSearchClient kakaoSearchClient;
+	private final LocationFacade locationFacade;
 
 	@GetMapping("/search/location")
 	public SlicingResponse<Place> search(@RequestParam("keyword") String keyword,
@@ -27,5 +35,13 @@ public class LocalController implements LocalApi {
 		Slice<Place> places = kakaoSearchClient.searchByKeyword(keyword, size, page);
 
 		return new SlicingResponse<>(HttpStatus.OK, places);
+	}
+
+	@PostMapping("/location/{momentId}")
+	public SingleResponse<Place> addPlace(@PathVariable Long momentId,
+		@Valid @RequestBody LocationRequest locationRequest) {
+
+		Place place = locationFacade.addPlace(momentId, locationRequest);
+		return new SingleResponse<>(HttpStatus.CREATED, place);
 	}
 }

--- a/src/main/java/com/genius/herewe/business/location/domain/Location.java
+++ b/src/main/java/com/genius/herewe/business/location/domain/Location.java
@@ -93,4 +93,11 @@ public class Location {
 		this.y = place.y();
 		this.phone = place.phone();
 	}
+
+	public void updateLocationIndex(int amount) {
+		if (this.locationIndex + amount <= 0) {
+			return;
+		}
+		this.locationIndex += amount;
+	}
 }

--- a/src/main/java/com/genius/herewe/business/location/domain/Location.java
+++ b/src/main/java/com/genius/herewe/business/location/domain/Location.java
@@ -11,6 +11,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +20,13 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@Table(name = "location",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_location_index_moment",
+			columnNames = {"location_index", "moment_id"}
+		)
+	})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Location {
 	@Id
@@ -29,7 +38,7 @@ public class Location {
 	@JoinColumn(name = "moment_id")
 	private Moment moment;
 
-	@Column(nullable = false)
+	@Column(nullable = false, name = "location_index")
 	private int locationIndex;
 
 	@Column(nullable = false)

--- a/src/main/java/com/genius/herewe/business/location/facade/DefaultLocationFacade.java
+++ b/src/main/java/com/genius/herewe/business/location/facade/DefaultLocationFacade.java
@@ -1,0 +1,42 @@
+package com.genius.herewe.business.location.facade;
+
+import static com.genius.herewe.core.global.exception.ErrorCode.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.genius.herewe.business.location.LocationRequest;
+import com.genius.herewe.business.location.domain.Location;
+import com.genius.herewe.business.location.search.dto.Place;
+import com.genius.herewe.business.location.service.LocationService;
+import com.genius.herewe.business.moment.domain.Moment;
+import com.genius.herewe.business.moment.service.MomentService;
+import com.genius.herewe.core.global.exception.BusinessException;
+
+import jakarta.persistence.OptimisticLockException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DefaultLocationFacade implements LocationFacade {
+	private final MomentService momentService;
+	private final LocationService locationService;
+
+	@Override
+	@Transactional
+	public Place addPlace(Long momentId, LocationRequest locationRequest) {
+		try {
+			Place place = locationRequest.place();
+			int locationIndex = locationRequest.locationIndex();
+
+			Moment moment = momentService.findById(momentId);
+			Location location = Location.createFromPlace(place, locationIndex);
+			location.addMoment(moment);
+			locationService.save(location);
+			return place;
+		} catch (OptimisticLockException e) {
+			throw new BusinessException(CONCURRENT_MODIFICATION_EXCEPTION);
+		}
+	}
+}

--- a/src/main/java/com/genius/herewe/business/location/facade/LocationFacade.java
+++ b/src/main/java/com/genius/herewe/business/location/facade/LocationFacade.java
@@ -1,0 +1,8 @@
+package com.genius.herewe.business.location.facade;
+
+import com.genius.herewe.business.location.LocationRequest;
+import com.genius.herewe.business.location.search.dto.Place;
+
+public interface LocationFacade {
+	Place addPlace(Long momentId, LocationRequest locationRequest);
+}

--- a/src/main/java/com/genius/herewe/business/location/search/dto/Place.java
+++ b/src/main/java/com/genius/herewe/business/location/search/dto/Place.java
@@ -3,29 +3,37 @@ package com.genius.herewe.business.location.search.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 @Schema(description = "Map API 결과를 담을 객체")
 public record Place(
+	@NotNull
 	@Schema(description = "이름")
 	@JsonProperty(value = "place_name")
 	String name,
+	@NotNull
 	@Schema(description = "해당 장소의 x 좌표")
 	@JsonProperty(value = "x")
 	Double x,
+	@NotNull
 	@Schema(description = "해당 장소의 y 좌표")
 	@JsonProperty(value = "y")
 	Double y,
+	@NotNull
 	@Schema(description = "지번 주소")
 	@JsonProperty(value = "address_name")
 	String address,
+	@NotNull
 	@Schema(description = "도로명 주소")
 	@JsonProperty(value = "road_address_name")
 	String roadAddress,
+	@NotNull
 	@Schema(description = "kakao map url")
 	@JsonProperty(value = "place_url")
 	String url,
+	@NotNull
 	@Schema(description = "전화번호")
 	@JsonProperty(value = "phone")
 	String phone

--- a/src/main/java/com/genius/herewe/business/location/service/LocationService.java
+++ b/src/main/java/com/genius/herewe/business/location/service/LocationService.java
@@ -23,6 +23,11 @@ public class LocationService {
 		return locationRepository.save(location);
 	}
 
+	@Transactional
+	public Location save(Location location) {
+		return locationRepository.save(location);
+	}
+
 	public Optional<Location> findMeetLocation(Long momentId) {
 		return locationRepository.findByLocationIndex(momentId, 1);
 	}

--- a/src/main/java/com/genius/herewe/business/location/service/LocationService.java
+++ b/src/main/java/com/genius/herewe/business/location/service/LocationService.java
@@ -31,4 +31,8 @@ public class LocationService {
 	public Optional<Location> findMeetLocation(Long momentId) {
 		return locationRepository.findByLocationIndex(momentId, 1);
 	}
+
+	public Optional<Location> findByIndex(Long momentId, int locationIndex) {
+		return locationRepository.findByLocationIndex(momentId, locationIndex);
+	}
 }

--- a/src/main/java/com/genius/herewe/business/moment/domain/Moment.java
+++ b/src/main/java/com/genius/herewe/business/moment/domain/Moment.java
@@ -115,4 +115,8 @@ public class Moment extends BaseTimeEntity implements FileHolder {
 	public void updateClosedAt(LocalDateTime closedAt) {
 		this.closedAt = closedAt;
 	}
+
+	public void updateLastModifiedTime() {
+		this.modifiedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/genius/herewe/business/moment/domain/Moment.java
+++ b/src/main/java/com/genius/herewe/business/moment/domain/Moment.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OptimisticLock;
 
 import com.genius.herewe.business.crew.domain.Crew;
 import com.genius.herewe.business.location.domain.Location;
@@ -23,6 +24,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -37,6 +39,9 @@ public class Moment extends BaseTimeEntity implements FileHolder {
 	@Column(name = "moment_id")
 	private Long id;
 
+	@Version
+	private Long version;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "crew_id")
 	private Crew crew;
@@ -45,6 +50,7 @@ public class Moment extends BaseTimeEntity implements FileHolder {
 	private List<MomentMember> momentMembers = new ArrayList<>();
 
 	@OneToMany(mappedBy = "moment", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OptimisticLock(excluded = false)
 	private List<Location> locations = new ArrayList<>();
 
 	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/genius/herewe/business/moment/repository/MomentRepository.java
+++ b/src/main/java/com/genius/herewe/business/moment/repository/MomentRepository.java
@@ -1,8 +1,18 @@
 package com.genius.herewe.business.moment.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.genius.herewe.business.moment.domain.Moment;
 
+import jakarta.persistence.LockModeType;
+
 public interface MomentRepository extends JpaRepository<Moment, Long> {
+	@Lock(LockModeType.OPTIMISTIC)
+	@Query("SELECT m FROM Moment m WHERE m.id = :momentId")
+	Optional<Moment> findByIdWithOptimisticLock(@Param("momentId") Long momentId);
 }

--- a/src/main/java/com/genius/herewe/business/moment/service/MomentService.java
+++ b/src/main/java/com/genius/herewe/business/moment/service/MomentService.java
@@ -9,12 +9,14 @@ import com.genius.herewe.business.moment.domain.Moment;
 import com.genius.herewe.business.moment.repository.MomentRepository;
 import com.genius.herewe.core.global.exception.BusinessException;
 
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MomentService {
+	private final EntityManager entityManager;
 	private final MomentRepository momentRepository;
 
 	@Transactional
@@ -27,8 +29,17 @@ public class MomentService {
 			.orElseThrow(() -> new BusinessException(MOMENT_NOT_FOUND));
 	}
 
+	public Moment findByIdWithOptimisticLock(Long momentId) {
+		return momentRepository.findByIdWithOptimisticLock(momentId)
+			.orElseThrow(() -> new BusinessException(MOMENT_NOT_FOUND));
+	}
+
 	@Transactional
 	public void delete(Moment moment) {
 		momentRepository.delete(moment);
+	}
+
+	public void flushChanges() {
+		entityManager.flush();
 	}
 }

--- a/src/main/java/com/genius/herewe/core/global/domain/BaseTimeEntity.java
+++ b/src/main/java/com/genius/herewe/core/global/domain/BaseTimeEntity.java
@@ -15,11 +15,10 @@ import lombok.Getter;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
+	@LastModifiedDate
+	@Column(name = "modified_at")
+	protected LocalDateTime modifiedAt;
 	@CreatedDate
 	@Column(name = "created_at", updatable = false)
 	private LocalDateTime createdAt;
-
-	@LastModifiedDate
-	@Column(name = "modified_at")
-	private LocalDateTime modifiedAt;
 }

--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+	CONCURRENT_MODIFICATION_EXCEPTION(HttpStatus.CONFLICT, "이 데이터는 다른 사용자에 의해 수정되었습니다. 다시 시도해주세요."),
 	REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST, "해당 항목은 필수 항목입니다. 입력 값을 확인해주세요."),
 	VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "데이터 전달 관련 유효성 검사에 실패했습니다."),
 	INVALID_PAGINATION_PARAM(HttpStatus.BAD_REQUEST, "페이지 번호는 0 이상이어야 하며, 페이지 사이즈는 1~15 중 하나여야 합니다."),
@@ -35,7 +36,6 @@ public enum ErrorCode {
 	MOMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 MOMENT를 찾을 수 없습니다."),
 	INVALID_MOMENT_CAPACITY(HttpStatus.BAD_REQUEST, "MOMENT의 최대 참여 가능 인원은 2명 이상이어야 합니다."),
 	INVALID_MOMENT_DATE(HttpStatus.BAD_REQUEST, "만남일자(meetAt)/마감일자(closedAt)는 오늘보다 나중이어야 하며, 만남일자가 마감일자보다 더 이후여야 합니다."),
-	NEED_MEET_PLACE(HttpStatus.NOT_FOUND, "만남 장소가 설정되지 않았습니다. 만남 장소를 설정해주세요."),
 
 	UNAUTHORIZED_ISSUE(HttpStatus.UNAUTHORIZED, "회원가입이 되어 있지 않은 사용자의 경우 JWT를 발급할 수 없습니다."),
 	JWT_NOT_VALID(HttpStatus.UNAUTHORIZED, "JWT가 유효하지 않습니다."),

--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -37,6 +37,8 @@ public enum ErrorCode {
 	INVALID_MOMENT_CAPACITY(HttpStatus.BAD_REQUEST, "MOMENT의 최대 참여 가능 인원은 2명 이상이어야 합니다."),
 	INVALID_MOMENT_DATE(HttpStatus.BAD_REQUEST, "만남일자(meetAt)/마감일자(closedAt)는 오늘보다 나중이어야 하며, 만남일자가 마감일자보다 더 이후여야 합니다."),
 
+	LOCATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 순서의 장소가 이미 추가되었습니다. 잠시 후 다시 시도해주세요."),
+
 	UNAUTHORIZED_ISSUE(HttpStatus.UNAUTHORIZED, "회원가입이 되어 있지 않은 사용자의 경우 JWT를 발급할 수 없습니다."),
 	JWT_NOT_VALID(HttpStatus.UNAUTHORIZED, "JWT가 유효하지 않습니다."),
 	JWT_NOT_FOUND_IN_HEADER(HttpStatus.UNAUTHORIZED, "Header에서 JWT를 찾을 수 없습니다."),


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/61-add-place-api` -> `main`

</br>

### 🛠️ 변경 사항
> 모먼트 세부세항 페이지에서 사용할 장소 등록 API를 개발합니다.
> 여기에서 발생할 수 있는 동시성 문제를 낙관적 락을 이용해 해결합니다.

#### ✅ 작업 상세 내용
- [x] Location에 복합 유니크 제약 조건 추가 (moment_id, location_index)
- [x] 낙관적 락을 위해 Moment 엔티티에 version 컬럼 추가
- [x] 장소 등록 API 개발 `POST /api/location/{momentId}`
    - [x] 낙관적 락으로 인한 예외 발생 시 CONCURRENT_MODIFICATION_EXCEPTION 예외 발생
    - [x] DB 수준에서의 유니크 제약 조건 예외 발생 시 LOCATION_ALREADY_EXISTS 예외 발생
- [x] `LocationApi`에 swagger 정보 추가

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/75cc0185-c498-48ff-9185-191c916cf605)

</br>

### 📚 연관된 이슈
#61 

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
