### PR TITLE
[FEAT] 크루에 대한 나의 정보 조회 API 개발 

### DIFF
--- a/src/main/java/com/genius/herewe/business/crew/controller/CrewApi.java
+++ b/src/main/java/com/genius/herewe/business/crew/controller/CrewApi.java
@@ -10,6 +10,7 @@ import com.genius.herewe.business.crew.dto.CrewCreateRequest;
 import com.genius.herewe.business.crew.dto.CrewMemberResponse;
 import com.genius.herewe.business.crew.dto.CrewModifyRequest;
 import com.genius.herewe.business.crew.dto.CrewPreviewResponse;
+import com.genius.herewe.business.crew.dto.CrewProfileResponse;
 import com.genius.herewe.business.crew.dto.CrewResponse;
 import com.genius.herewe.business.invitation.dto.InvitationRequest;
 import com.genius.herewe.core.global.response.CommonResponse;
@@ -28,6 +29,47 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 
 public interface CrewApi {
+	@Operation(summary = "크루에 대한 나의 정보 조회", description = "크루에 대한 나의 정보(닉네임, 크루 내 권한) 조회")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "크루에 대한 나의 정보 조회 성공"
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = """
+				1. userId(식별자)를 통해 사용자 엔티티를 찾지 못했을 때
+				2. userId, crewId(식별자)를 통해 크루의 참여 정보를 찾지 못했을 때
+				""",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "1. userId(식별자)를 통해 사용자 엔티티를 찾지 못했을 때",
+						value = """
+							{
+								"resultCode": "404",
+								"code": "MEMBER_NOT_FOUND",
+								"message": "사용자를 찾을 수 없습니다."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "2. userId, crewId(식별자)를 통해 크루의 참여 정보를 찾지 못했을 때",
+						value = """
+							{
+								"resultCode": "404",
+								"code": "CREW_JOIN_INFO_NOT_FOUND",
+								"message": "해당 크루에 대한 참여 정보가 없습니다."
+							}
+							"""
+					)
+				}
+			)
+		)
+	})
+	SingleResponse<CrewProfileResponse> inquiryCrewProfile(@HereWeUser User user, @PathVariable Long crewId);
+
 	@Operation(summary = "내가 참여한 크루 리스트 조회", description = "참여한 크루에 대해 pagination 형식으로 조회")
 	@ApiResponses({
 		@ApiResponse(

--- a/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
+++ b/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
@@ -20,6 +20,7 @@ import com.genius.herewe.business.crew.dto.CrewIdResponse;
 import com.genius.herewe.business.crew.dto.CrewMemberResponse;
 import com.genius.herewe.business.crew.dto.CrewModifyRequest;
 import com.genius.herewe.business.crew.dto.CrewPreviewResponse;
+import com.genius.herewe.business.crew.dto.CrewProfileResponse;
 import com.genius.herewe.business.crew.dto.CrewResponse;
 import com.genius.herewe.business.crew.facade.CrewFacade;
 import com.genius.herewe.business.invitation.dto.InvitationRequest;
@@ -39,6 +40,13 @@ import lombok.RequiredArgsConstructor;
 public class CrewController implements CrewApi {
 	private final CrewFacade crewFacade;
 	private final InvitationFacade invitationFacade;
+
+	@GetMapping("/profile/{crewId}")
+	public SingleResponse<CrewProfileResponse> inquiryCrewProfile(@HereWeUser User user,
+		@PathVariable Long crewId) {
+		CrewProfileResponse crewProfileResponse = crewFacade.inquiryCrewProfile(user.getId(), crewId);
+		return new SingleResponse<>(HttpStatus.OK, crewProfileResponse);
+	}
 
 	@GetMapping("/my")
 	public PagingResponse<CrewPreviewResponse> inquiryMyCrews(

--- a/src/main/java/com/genius/herewe/business/crew/dto/CrewProfileResponse.java
+++ b/src/main/java/com/genius/herewe/business/crew/dto/CrewProfileResponse.java
@@ -1,0 +1,14 @@
+package com.genius.herewe.business.crew.dto;
+
+import com.genius.herewe.business.crew.domain.CrewRole;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "크루에 대한 나의 정보 응답 DTO")
+public record CrewProfileResponse(
+	@Schema(description = "사용자의 닉네임")
+	String nickname,
+	@Schema(description = "크루에서의 사용자의 권한", example = "LEADER   or   MEMBER")
+	CrewRole crewRole
+) {
+}

--- a/src/main/java/com/genius/herewe/business/crew/facade/CrewFacade.java
+++ b/src/main/java/com/genius/herewe/business/crew/facade/CrewFacade.java
@@ -8,9 +8,12 @@ import com.genius.herewe.business.crew.dto.CrewExpelRequest;
 import com.genius.herewe.business.crew.dto.CrewMemberResponse;
 import com.genius.herewe.business.crew.dto.CrewModifyRequest;
 import com.genius.herewe.business.crew.dto.CrewPreviewResponse;
+import com.genius.herewe.business.crew.dto.CrewProfileResponse;
 import com.genius.herewe.business.crew.dto.CrewResponse;
 
 public interface CrewFacade {
+	CrewProfileResponse inquiryCrewProfile(Long userId, Long crewId);
+
 	Page<CrewPreviewResponse> inquiryMyCrews(Long userId, Pageable pageable);
 
 	CrewResponse inquiryCrew(Long userId, Long crewId);

--- a/src/main/java/com/genius/herewe/business/crew/facade/DefaultCrewFacade.java
+++ b/src/main/java/com/genius/herewe/business/crew/facade/DefaultCrewFacade.java
@@ -15,6 +15,7 @@ import com.genius.herewe.business.crew.dto.CrewExpelRequest;
 import com.genius.herewe.business.crew.dto.CrewMemberResponse;
 import com.genius.herewe.business.crew.dto.CrewModifyRequest;
 import com.genius.herewe.business.crew.dto.CrewPreviewResponse;
+import com.genius.herewe.business.crew.dto.CrewProfileResponse;
 import com.genius.herewe.business.crew.dto.CrewResponse;
 import com.genius.herewe.business.crew.service.CrewMemberService;
 import com.genius.herewe.business.crew.service.CrewService;
@@ -34,6 +35,13 @@ public class DefaultCrewFacade implements CrewFacade {
 	private final CrewService crewService;
 	private final CrewMemberService crewMemberService;
 	private final FilesStorage filesStorage;
+
+	@Override
+	public CrewProfileResponse inquiryCrewProfile(Long userId, Long crewId) {
+		User user = userService.findById(userId);
+		CrewMember crewMember = crewMemberService.find(userId, crewId);
+		return new CrewProfileResponse(user.getNickname(), crewMember.getRole());
+	}
 
 	@Override
 	public Page<CrewPreviewResponse> inquiryMyCrews(Long userId, Pageable pageable) {

--- a/src/main/java/com/genius/herewe/business/location/controller/LocationApi.java
+++ b/src/main/java/com/genius/herewe/business/location/controller/LocationApi.java
@@ -44,7 +44,7 @@ public interface LocationApi {
 				examples = {
 					@ExampleObject(
 						name = "momentId(식별자)를 통해 모먼트 엔티티를 찾지 못했을 때",
-						description = """
+						value = """
 							{
 								"resultCode": "404",
 								"code": "MOMENT_NOT_FOUND",
@@ -66,7 +66,7 @@ public interface LocationApi {
 				examples = {
 					@ExampleObject(
 						name = "1. 동시성 문제로 인해 예외 발생한 경우",
-						description = """
+						value = """
 							{
 								"resultCode": "409",
 								"code": "CONCURRENT_MODIFICATION_EXCEPTION",
@@ -76,7 +76,7 @@ public interface LocationApi {
 					),
 					@ExampleObject(
 						name = "2. 해당 인덱스로 이미 장소가 등록되어 있는 경우",
-						description = """
+						value = """
 							{
 								"resultCode": "409",
 								"code": "LOCATION_ALREADY_EXISTS",


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/70-inquiry-my-crew-info` → `main`

</br>

### 🛠️ 변경 사항
> 크루에 대한 나의 정보(크루 내 권한, 사용자 닉네임) 조회하는 API를 개발합니다.

#### ✅ 작업 상세 내용
- [x] 크루에 대한 나의 정보(닉네임, 크루 권한) 조회 API `GET /api/crew/profile/{crewId}` 개발
- [x] 크루에 대한 나의 정보 조회 swagger 정보 입력
- [x] 단위 테스트 코드 작성

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/56ce5bd8-8aba-4871-ae4d-1816989d7786)

</br>

### 📚 연관된 이슈
#70 

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
