### PR TITLE
[FEAT] 모먼트 탭에서 리스트 조회 기능

### DIFF
--- a/src/main/java/com/genius/herewe/business/location/domain/Location.java
+++ b/src/main/java/com/genius/herewe/business/location/domain/Location.java
@@ -93,6 +93,20 @@ public class Location {
 			.build();
 	}
 
+	public static Location createDummy() {
+		return Location.builder()
+			.locationIndex(0)
+			.placeId(0L)
+			.name("")
+			.address("")
+			.roadAddress("")
+			.url("")
+			.x(0.0)
+			.y(0.0)
+			.phone("")
+			.build();
+	}
+
 	//== 연관관계 편의 메서드 ==//
 	public void addMoment(Moment moment) {
 		this.moment = moment;

--- a/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
+++ b/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
@@ -16,4 +16,7 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
 
 	@Query("SELECT l FROM Location l WHERE l.moment.id = :momentId ORDER BY l.locationIndex ASC LIMIT 100")
 	List<Location> findAllInMoment(@Param("momentId") Long momentId);
+
+	@Query("SELECT l FROM Location l WHERE l.locationIndex = 1 AND l.moment.id IN :momentIds")
+	List<Location> findMeetingLocationsByCrewId(List<Long> momentIds);
 }

--- a/src/main/java/com/genius/herewe/business/location/service/LocationService.java
+++ b/src/main/java/com/genius/herewe/business/location/service/LocationService.java
@@ -29,15 +29,19 @@ public class LocationService {
 		return locationRepository.save(location);
 	}
 
-	public Optional<Location> findMeetLocation(Long momentId) {
-		return locationRepository.findByLocationIndex(momentId, 1);
-	}
-
 	public Optional<Location> findByIndex(Long momentId, int locationIndex) {
 		return locationRepository.findByLocationIndex(momentId, locationIndex);
 	}
 
 	public List<Location> findAllInMoment(Long momentId) {
 		return locationRepository.findAllInMoment(momentId);
+	}
+
+	public Optional<Location> findMeetLocation(Long momentId) {
+		return locationRepository.findByLocationIndex(momentId, 1);
+	}
+
+	public List<Location> findMeetingLocationsByCrewId(List<Long> momentIds) {
+		return locationRepository.findMeetingLocationsByCrewId(momentIds);
 	}
 }

--- a/src/main/java/com/genius/herewe/business/moment/controller/MomentApi.java
+++ b/src/main/java/com/genius/herewe/business/moment/controller/MomentApi.java
@@ -1,15 +1,18 @@
 package com.genius.herewe.business.moment.controller;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.genius.herewe.business.moment.dto.MomentMemberResponse;
+import com.genius.herewe.business.moment.dto.MomentPreviewResponse;
 import com.genius.herewe.business.moment.dto.MomentRequest;
 import com.genius.herewe.business.moment.dto.MomentResponse;
 import com.genius.herewe.core.global.response.CommonResponse;
 import com.genius.herewe.core.global.response.ExceptionResponse;
+import com.genius.herewe.core.global.response.PagingResponse;
 import com.genius.herewe.core.global.response.SingleResponse;
 import com.genius.herewe.core.global.response.SlicingResponse;
 import com.genius.herewe.core.security.annotation.HereWeUser;
@@ -23,6 +26,18 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 public interface MomentApi {
+
+	@Operation(summary = "크루에 속한 모먼트 리스트 조회", description = "특정 크루에 속한 모먼트들을 페이지네이션으로 조회")
+	@ApiResponses(
+		@ApiResponse(
+			responseCode = "200",
+			description = "크루에 속한 모먼트 리스트 조회 성공"
+		)
+	)
+	PagingResponse<MomentPreviewResponse> inquiryMomentList(@HereWeUser User user,
+		@PathVariable Long crewId,
+		@PageableDefault(size = 20) Pageable pageable);
+
 	@Operation(summary = "특정 모먼트 정보 상세 조회", description = "특정 모먼트에 대한 상세 정보 조회")
 	@ApiResponses({
 		@ApiResponse(

--- a/src/main/java/com/genius/herewe/business/moment/controller/MomentController.java
+++ b/src/main/java/com/genius/herewe/business/moment/controller/MomentController.java
@@ -2,6 +2,7 @@ package com.genius.herewe.business.moment.controller;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
@@ -17,10 +18,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.genius.herewe.business.moment.dto.MomentMemberResponse;
+import com.genius.herewe.business.moment.dto.MomentPreviewResponse;
 import com.genius.herewe.business.moment.dto.MomentRequest;
 import com.genius.herewe.business.moment.dto.MomentResponse;
 import com.genius.herewe.business.moment.facade.MomentFacade;
 import com.genius.herewe.core.global.response.CommonResponse;
+import com.genius.herewe.core.global.response.PagingResponse;
 import com.genius.herewe.core.global.response.SingleResponse;
 import com.genius.herewe.core.global.response.SlicingResponse;
 import com.genius.herewe.core.security.annotation.HereWeUser;
@@ -35,6 +38,17 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/moment")
 public class MomentController implements MomentApi {
 	private final MomentFacade momentFacade;
+
+	@GetMapping("/crew/{crewId}")
+	public PagingResponse<MomentPreviewResponse> inquiryMomentList(@HereWeUser User user,
+		@PathVariable Long crewId,
+		@PageableDefault(size = 20) Pageable pageable) {
+
+		LocalDateTime now = LocalDateTime.now();
+		Page<MomentPreviewResponse> momentPreviewResponses = momentFacade.inquiryList(
+			user.getId(), crewId, now, pageable);
+		return new PagingResponse<>(HttpStatus.OK, momentPreviewResponses);
+	}
 
 	@GetMapping("/{momentId}")
 	public SingleResponse<MomentResponse> inquirySingleMoment(@HereWeUser User user, @PathVariable Long momentId) {

--- a/src/main/java/com/genius/herewe/business/moment/domain/ParticipantStatus.java
+++ b/src/main/java/com/genius/herewe/business/moment/domain/ParticipantStatus.java
@@ -1,0 +1,14 @@
+package com.genius.herewe.business.moment.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ParticipantStatus {
+	AVAILABLE("참여가능"),
+	PARTICIPATING("참여중"),
+	DEADLINE_PASSED("마감");
+
+	private final String value;
+}

--- a/src/main/java/com/genius/herewe/business/moment/dto/MomentPreviewResponse.java
+++ b/src/main/java/com/genius/herewe/business/moment/dto/MomentPreviewResponse.java
@@ -1,0 +1,44 @@
+package com.genius.herewe.business.moment.dto;
+
+import java.time.LocalDateTime;
+
+import com.genius.herewe.business.moment.domain.Moment;
+import com.genius.herewe.business.moment.domain.ParticipantStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "크루 내 모먼트 탭에서 모먼트 목록 조회 시 응답 DTO, 간략한 정보 제공")
+public record MomentPreviewResponse(
+	@Schema(description = "모먼트의 식별자(PK)", example = "1")
+	Long momentId,
+	@Schema(description = "모먼트에 대한 사용자의 상태", example = "참여가능   or   참여중   or   마감")
+	String status,
+	@Schema(description = "모먼트의 이름", example = "눈물나게 맛있는 훠궈 먹으러 가자")
+	String name,
+	@Schema(description = "모먼트 만남일자", example = "2025-04-28T12:31:00")
+	LocalDateTime meetAt,
+	@Schema(description = "만남 장소 이름", example = "하이디라오 강남점")
+	String meetingPlaceName,
+	@Schema(description = "현재까지 참여한 인원의 수", example = "5")
+	Integer participantCount,
+	@Schema(description = "참여 가능한 최대 정원", example = "20")
+	Integer capacity,
+	@Schema(description = "모먼트 참여 마감 일자", example = "2025-04-05T12:31:00")
+	LocalDateTime closedAt
+) {
+
+	public static MomentPreviewResponse create(Moment moment, ParticipantStatus status, String placeName) {
+		return MomentPreviewResponse.builder()
+			.momentId(moment.getId())
+			.status(status.getValue())
+			.name(moment.getName())
+			.meetAt(moment.getMeetAt())
+			.meetingPlaceName(placeName)
+			.participantCount(moment.getParticipantCount())
+			.capacity(moment.getCapacity())
+			.closedAt(moment.getClosedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/genius/herewe/business/moment/facade/MomentFacade.java
+++ b/src/main/java/com/genius/herewe/business/moment/facade/MomentFacade.java
@@ -2,15 +2,19 @@ package com.genius.herewe.business.moment.facade;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import com.genius.herewe.business.moment.dto.MomentMemberResponse;
+import com.genius.herewe.business.moment.dto.MomentPreviewResponse;
 import com.genius.herewe.business.moment.dto.MomentRequest;
 import com.genius.herewe.business.moment.dto.MomentResponse;
 import com.genius.herewe.core.user.domain.User;
 
 public interface MomentFacade {
+	Page<MomentPreviewResponse> inquiryList(Long userId, Long crewId, LocalDateTime now, Pageable pageable);
+
 	MomentResponse inquirySingle(User user, Long momentId);
 
 	MomentResponse create(Long userId, Long crewId, MomentRequest momentRequest);

--- a/src/main/java/com/genius/herewe/business/moment/repository/MomentMemberRepository.java
+++ b/src/main/java/com/genius/herewe/business/moment/repository/MomentMemberRepository.java
@@ -1,5 +1,6 @@
 package com.genius.herewe.business.moment.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,4 +13,7 @@ public interface MomentMemberRepository extends JpaRepository<MomentMember, Long
 
 	@Query("SELECT m FROM MomentMember m WHERE m.user.id = :userId AND m.moment.id = :momentId")
 	Optional<MomentMember> findByJoinInfo(@Param("userId") Long userId, @Param("momentId") Long momentId);
+
+	@Query("SELECT mm.moment.id FROM MomentMember mm WHERE mm.moment.id IN :momentIds")
+	List<Long> findIdsInMoment(@Param("momentIds") List<Long> momentIds);
 }

--- a/src/main/java/com/genius/herewe/business/moment/repository/MomentRepository.java
+++ b/src/main/java/com/genius/herewe/business/moment/repository/MomentRepository.java
@@ -2,6 +2,8 @@ package com.genius.herewe.business.moment.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +17,7 @@ public interface MomentRepository extends JpaRepository<Moment, Long> {
 	@Lock(LockModeType.OPTIMISTIC)
 	@Query("SELECT m FROM Moment m WHERE m.id = :momentId")
 	Optional<Moment> findByIdWithOptimisticLock(@Param("momentId") Long momentId);
+
+	@Query("SELECT m FROM Moment m WHERE m.crew.id = :crewId ORDER BY m.createdAt")
+	Page<Moment> findAllByPaging(@Param("crewId") Long crewId, Pageable pageable);
 }

--- a/src/main/java/com/genius/herewe/business/moment/service/MomentMemberService.java
+++ b/src/main/java/com/genius/herewe/business/moment/service/MomentMemberService.java
@@ -1,5 +1,6 @@
 package com.genius.herewe.business.moment.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
@@ -37,5 +38,9 @@ public class MomentMemberService {
 
 	public Slice<MomentMemberResponse> findAllJoinedUsers(Long momentId, Pageable pageable) {
 		return queryRepository.findAllJoinedUsers(momentId, pageable);
+	}
+
+	public List<Long> findAllJoinedMomentIds(List<Long> momentIds) {
+		return momentMemberRepository.findIdsInMoment(momentIds);
 	}
 }

--- a/src/main/java/com/genius/herewe/business/moment/service/MomentService.java
+++ b/src/main/java/com/genius/herewe/business/moment/service/MomentService.java
@@ -2,6 +2,8 @@ package com.genius.herewe.business.moment.service;
 
 import static com.genius.herewe.core.global.exception.ErrorCode.*;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +34,10 @@ public class MomentService {
 	public Moment findByIdWithOptimisticLock(Long momentId) {
 		return momentRepository.findByIdWithOptimisticLock(momentId)
 			.orElseThrow(() -> new BusinessException(MOMENT_NOT_FOUND));
+	}
+
+	public Page<Moment> findAllByPaging(Long crewId, Pageable pageable) {
+		return momentRepository.findAllByPaging(crewId, pageable);
 	}
 
 	@Transactional


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/58-inquiry-moment-list` -> `main`

</br>

### 🛠️ 변경 사항
> 특정 크루 내에 속한 모먼트 리스트를 조회하는 API를 개발합니다.

#### ✅ 작업 상세 내용
- [x] 특정 크루 내에 속한 모먼트 리스트 조회 `GET /api/moment/crew/{crewId}`
- [x] N+1 문제 해결을 위해 3단계 쿼리 적용 (Moment -> MomentMember -> Location 차례로 조회 후, 응답 DTO 구성)
- [x] swagger 정보 입력

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/e7ebb66b-d3df-40e8-91a6-bbfec4945101)


</br>

### 📚 연관된 이슈
#58

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
