### PR TITLE
 [FEAT] 다가오는 모먼트 조회 API 개발

### DIFF
--- a/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
+++ b/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
@@ -51,7 +51,7 @@ public class CrewController implements CrewApi {
 	@GetMapping("/my")
 	public PagingResponse<CrewPreviewResponse> inquiryMyCrews(
 		@HereWeUser User user,
-		@PageableDefault(size = 10, page = 0) Pageable pageable) {
+		@PageableDefault(size = 20, page = 0) Pageable pageable) {
 
 		Page<CrewPreviewResponse> crewPreviewResponses = crewFacade.inquiryMyCrews(user.getId(), pageable);
 		return new PagingResponse<>(HttpStatus.OK, crewPreviewResponses);

--- a/src/main/java/com/genius/herewe/business/crew/repository/CrewRepository.java
+++ b/src/main/java/com/genius/herewe/business/crew/repository/CrewRepository.java
@@ -1,8 +1,20 @@
 package com.genius.herewe.business.crew.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.genius.herewe.business.crew.domain.Crew;
+import com.genius.herewe.business.crew.repository.dto.CrewMomentPair;
 
 public interface CrewRepository extends JpaRepository<Crew, Long> {
+
+	@Query("""
+		SELECT m.id as momentId, c as crew
+		FROM Moment m
+		JOIN m.crew c
+		WHERE m.id IN :momentIds
+		""")
+	List<CrewMomentPair> findAllInMomentIds(List<Long> momentIds);
 }

--- a/src/main/java/com/genius/herewe/business/crew/repository/dto/CrewMomentPair.java
+++ b/src/main/java/com/genius/herewe/business/crew/repository/dto/CrewMomentPair.java
@@ -1,0 +1,9 @@
+package com.genius.herewe.business.crew.repository.dto;
+
+import com.genius.herewe.business.crew.domain.Crew;
+
+public interface CrewMomentPair {
+	Long getMomentId();
+
+	Crew getCrew();
+}

--- a/src/main/java/com/genius/herewe/business/crew/service/CrewService.java
+++ b/src/main/java/com/genius/herewe/business/crew/service/CrewService.java
@@ -1,10 +1,15 @@
 package com.genius.herewe.business.crew.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.genius.herewe.business.crew.domain.Crew;
 import com.genius.herewe.business.crew.repository.CrewRepository;
+import com.genius.herewe.business.crew.repository.dto.CrewMomentPair;
 import com.genius.herewe.core.global.exception.BusinessException;
 import com.genius.herewe.core.global.exception.ErrorCode;
 
@@ -29,5 +34,15 @@ public class CrewService {
 	@Transactional
 	public void delete(Crew crew) {
 		crewRepository.delete(crew);
+	}
+
+	public Map<Long, Crew> findAllInMoments(List<Long> momentIds) {
+		List<CrewMomentPair> pairs = crewRepository.findAllInMomentIds(momentIds);
+		return pairs.stream().collect(
+			Collectors.toMap(
+				CrewMomentPair::getMomentId,
+				CrewMomentPair::getCrew
+			)
+		);
 	}
 }

--- a/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
+++ b/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
@@ -18,5 +18,5 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
 	List<Location> findAllInMoment(@Param("momentId") Long momentId);
 
 	@Query("SELECT l FROM Location l WHERE l.locationIndex = 1 AND l.moment.id IN :momentIds")
-	List<Location> findMeetingLocationsByCrewId(List<Long> momentIds);
+	List<Location> findMeetingLocationsByIds(List<Long> momentIds);
 }

--- a/src/main/java/com/genius/herewe/business/location/service/LocationService.java
+++ b/src/main/java/com/genius/herewe/business/location/service/LocationService.java
@@ -1,7 +1,9 @@
 package com.genius.herewe.business.location.service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,7 +43,12 @@ public class LocationService {
 		return locationRepository.findByLocationIndex(momentId, 1);
 	}
 
-	public List<Location> findMeetingLocationsByCrewId(List<Long> momentIds) {
-		return locationRepository.findMeetingLocationsByCrewId(momentIds);
+	public Map<Long, Location> findMeetingLocationsInIds(List<Long> momentIds) {
+		List<Location> meetingLocations = locationRepository.findMeetingLocationsByIds(momentIds);
+		return meetingLocations.stream()
+			.collect(Collectors.toMap(
+				location -> location.getMoment().getId(),
+				location -> location
+			));
 	}
 }

--- a/src/main/java/com/genius/herewe/business/moment/controller/MomentApi.java
+++ b/src/main/java/com/genius/herewe/business/moment/controller/MomentApi.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.genius.herewe.business.moment.dto.MomentIncomingResponse;
 import com.genius.herewe.business.moment.dto.MomentMemberResponse;
 import com.genius.herewe.business.moment.dto.MomentPreviewResponse;
 import com.genius.herewe.business.moment.dto.MomentRequest;
@@ -26,6 +27,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 public interface MomentApi {
+
+	@Operation(summary = "다가오는 모먼트 리스트 조회", description = "다가오는 모먼트들을 페이지네이션으로 조회")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "다가오는 모먼트 리스트 조회 성공"
+		)
+	})
+	PagingResponse<MomentIncomingResponse> inquiryIncomingMoments(@HereWeUser User user,
+		@PageableDefault(size = 20) Pageable pageable);
 
 	@Operation(summary = "크루에 속한 모먼트 리스트 조회", description = "특정 크루에 속한 모먼트들을 페이지네이션으로 조회")
 	@ApiResponses(

--- a/src/main/java/com/genius/herewe/business/moment/controller/MomentApi.java
+++ b/src/main/java/com/genius/herewe/business/moment/controller/MomentApi.java
@@ -34,7 +34,7 @@ public interface MomentApi {
 			description = "크루에 속한 모먼트 리스트 조회 성공"
 		)
 	)
-	PagingResponse<MomentPreviewResponse> inquiryMomentList(@HereWeUser User user,
+	PagingResponse<MomentPreviewResponse> inquiryMoments(@HereWeUser User user,
 		@PathVariable Long crewId,
 		@PageableDefault(size = 20) Pageable pageable);
 

--- a/src/main/java/com/genius/herewe/business/moment/controller/MomentController.java
+++ b/src/main/java/com/genius/herewe/business/moment/controller/MomentController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.genius.herewe.business.moment.dto.MomentIncomingResponse;
 import com.genius.herewe.business.moment.dto.MomentMemberResponse;
 import com.genius.herewe.business.moment.dto.MomentPreviewResponse;
 import com.genius.herewe.business.moment.dto.MomentRequest;
@@ -39,8 +40,18 @@ import lombok.extern.slf4j.Slf4j;
 public class MomentController implements MomentApi {
 	private final MomentFacade momentFacade;
 
+	@GetMapping
+	public PagingResponse<MomentIncomingResponse> inquiryIncomingMoments(@HereWeUser User user,
+		@PageableDefault(size = 20) Pageable pageable) {
+
+		LocalDateTime now = LocalDateTime.now();
+		Page<MomentIncomingResponse> momentIncomingResponses = momentFacade.inquiryIncomingList(
+			user.getId(), now, pageable);
+		return new PagingResponse<>(HttpStatus.OK, momentIncomingResponses);
+	}
+
 	@GetMapping("/crew/{crewId}")
-	public PagingResponse<MomentPreviewResponse> inquiryMomentList(@HereWeUser User user,
+	public PagingResponse<MomentPreviewResponse> inquiryMoments(@HereWeUser User user,
 		@PathVariable Long crewId,
 		@PageableDefault(size = 20) Pageable pageable) {
 

--- a/src/main/java/com/genius/herewe/business/moment/dto/MomentIncomingResponse.java
+++ b/src/main/java/com/genius/herewe/business/moment/dto/MomentIncomingResponse.java
@@ -1,0 +1,22 @@
+package com.genius.herewe.business.moment.dto;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "다가오는 모먼트 응답 객체")
+public record MomentIncomingResponse(
+	@Schema(description = "모먼트 식별자(PK)", example = "1")
+	Long momentId,
+	@Schema(description = "모먼트가 속한 크루의 이름", example = "눈물나게 맛있는거 먹는 사람들")
+	String crewName,
+	@Schema(description = "모먼트의 이름", example = "눈물나게 맛있는 훠궈 먹으러 가는 날")
+	String momentName,
+	@Schema(description = "모먼트 만남일자", example = "2025-04-28T12:31:00")
+	LocalDateTime meetAt,
+	@Schema(description = "모먼트 만남 장소", example = "하이디라오 강남점")
+	String meetPlaceName
+) {
+}

--- a/src/main/java/com/genius/herewe/business/moment/facade/DefaultMomentFacade.java
+++ b/src/main/java/com/genius/herewe/business/moment/facade/DefaultMomentFacade.java
@@ -52,16 +52,15 @@ public class DefaultMomentFacade implements MomentFacade {
 
 	@Override
 	public Page<MomentIncomingResponse> inquiryIncomingList(Long userId, LocalDateTime now, Pageable pageable) {
-		//
-		Page<Long> joinedMomentIds = momentMemberService.findAllJoinedMomentIds(userId, pageable);
-		List<Long> momentIds = joinedMomentIds.getContent();
+		Page<Moment> joinedMoments = momentService.findAllJoinedMoments(userId, now, pageable);
 
-		List<Moment> joinedMoments = momentService.findAllJoined(momentIds, now);
+		List<Moment> moments = joinedMoments.getContent();
+		List<Long> momentIds = moments.stream().map(Moment::getId).toList();
+
 		Map<Long, Location> locationInfos = locationService.findMeetingLocationsInIds(momentIds);
-
 		Map<Long, Crew> crewInfos = crewService.findAllInMoments(momentIds);
 
-		List<MomentIncomingResponse> incomingResponses = joinedMoments.stream().map(moment -> {
+		List<MomentIncomingResponse> incomingResponses = moments.stream().map(moment -> {
 			Crew crew = crewInfos.get(moment.getId());
 			Location location = locationInfos.get(moment.getId());
 
@@ -74,7 +73,7 @@ public class DefaultMomentFacade implements MomentFacade {
 				.build();
 		}).toList();
 
-		return new PageImpl<>(incomingResponses, pageable, joinedMomentIds.getTotalElements());
+		return new PageImpl<>(incomingResponses, pageable, joinedMoments.getTotalElements());
 	}
 
 	@Override

--- a/src/main/java/com/genius/herewe/business/moment/facade/MomentFacade.java
+++ b/src/main/java/com/genius/herewe/business/moment/facade/MomentFacade.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import com.genius.herewe.business.moment.dto.MomentIncomingResponse;
 import com.genius.herewe.business.moment.dto.MomentMemberResponse;
 import com.genius.herewe.business.moment.dto.MomentPreviewResponse;
 import com.genius.herewe.business.moment.dto.MomentRequest;
@@ -13,6 +14,8 @@ import com.genius.herewe.business.moment.dto.MomentResponse;
 import com.genius.herewe.core.user.domain.User;
 
 public interface MomentFacade {
+	Page<MomentIncomingResponse> inquiryIncomingList(Long userId, LocalDateTime now, Pageable pageable);
+
 	Page<MomentPreviewResponse> inquiryList(Long userId, Long crewId, LocalDateTime now, Pageable pageable);
 
 	MomentResponse inquirySingle(User user, Long momentId);

--- a/src/main/java/com/genius/herewe/business/moment/repository/MomentMemberRepository.java
+++ b/src/main/java/com/genius/herewe/business/moment/repository/MomentMemberRepository.java
@@ -3,6 +3,8 @@ package com.genius.herewe.business.moment.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,4 +18,9 @@ public interface MomentMemberRepository extends JpaRepository<MomentMember, Long
 
 	@Query("SELECT mm.moment.id FROM MomentMember mm WHERE mm.moment.id IN :momentIds")
 	List<Long> findIdsInMoment(@Param("momentIds") List<Long> momentIds);
+
+	@Query(
+		value = "SELECT DISTINCT mm.moment.id FROM MomentMember mm WHERE mm.user.id = :userId",
+		countQuery = "SELECT COUNT(DISTINCT mm.moment.id) FROM MomentMember mm WHERE mm.user.id = :userId")
+	Page<Long> findAllJoinedMomentIds(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/genius/herewe/business/moment/repository/MomentRepository.java
+++ b/src/main/java/com/genius/herewe/business/moment/repository/MomentRepository.java
@@ -1,7 +1,5 @@
 package com.genius.herewe.business.moment.repository;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -22,12 +20,4 @@ public interface MomentRepository extends JpaRepository<Moment, Long> {
 
 	@Query("SELECT m FROM Moment m WHERE m.crew.id = :crewId ORDER BY m.createdAt")
 	Page<Moment> findAllInCrewByPaging(@Param("crewId") Long crewId, Pageable pageable);
-
-	@Query("""
-		SELECT m
-		FROM Moment m
-		WHERE m.id IN :momentIds AND m.meetAt >= :currentDate
-		ORDER BY m.meetAt ASC
-		""")
-	List<Moment> findAllJoined(@Param("momentIds") List<Long> momentIds, @Param("currentDate") LocalDateTime now);
 }

--- a/src/main/java/com/genius/herewe/business/moment/repository/MomentRepository.java
+++ b/src/main/java/com/genius/herewe/business/moment/repository/MomentRepository.java
@@ -1,5 +1,7 @@
 package com.genius.herewe.business.moment.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -19,5 +21,13 @@ public interface MomentRepository extends JpaRepository<Moment, Long> {
 	Optional<Moment> findByIdWithOptimisticLock(@Param("momentId") Long momentId);
 
 	@Query("SELECT m FROM Moment m WHERE m.crew.id = :crewId ORDER BY m.createdAt")
-	Page<Moment> findAllByPaging(@Param("crewId") Long crewId, Pageable pageable);
+	Page<Moment> findAllInCrewByPaging(@Param("crewId") Long crewId, Pageable pageable);
+
+	@Query("""
+		SELECT m
+		FROM Moment m
+		WHERE m.id IN :momentIds AND m.meetAt >= :currentDate
+		ORDER BY m.meetAt ASC
+		""")
+	List<Moment> findAllJoined(@Param("momentIds") List<Long> momentIds, @Param("currentDate") LocalDateTime now);
 }

--- a/src/main/java/com/genius/herewe/business/moment/service/MomentMemberService.java
+++ b/src/main/java/com/genius/herewe/business/moment/service/MomentMemberService.java
@@ -3,7 +3,6 @@ package com.genius.herewe.business.moment.service;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -43,9 +42,5 @@ public class MomentMemberService {
 
 	public List<Long> findAllInMomentIds(List<Long> momentIds) {
 		return momentMemberRepository.findIdsInMoment(momentIds);
-	}
-
-	public Page<Long> findAllJoinedMomentIds(Long userId, Pageable pageable) {
-		return momentMemberRepository.findAllJoinedMomentIds(userId, pageable);
 	}
 }

--- a/src/main/java/com/genius/herewe/business/moment/service/MomentMemberService.java
+++ b/src/main/java/com/genius/herewe/business/moment/service/MomentMemberService.java
@@ -3,6 +3,7 @@ package com.genius.herewe.business.moment.service;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -40,7 +41,11 @@ public class MomentMemberService {
 		return queryRepository.findAllJoinedUsers(momentId, pageable);
 	}
 
-	public List<Long> findAllJoinedMomentIds(List<Long> momentIds) {
+	public List<Long> findAllInMomentIds(List<Long> momentIds) {
 		return momentMemberRepository.findIdsInMoment(momentIds);
+	}
+
+	public Page<Long> findAllJoinedMomentIds(Long userId, Pageable pageable) {
+		return momentMemberRepository.findAllJoinedMomentIds(userId, pageable);
 	}
 }

--- a/src/main/java/com/genius/herewe/business/moment/service/MomentService.java
+++ b/src/main/java/com/genius/herewe/business/moment/service/MomentService.java
@@ -3,7 +3,6 @@ package com.genius.herewe.business.moment.service;
 import static com.genius.herewe.core.global.exception.ErrorCode.*;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.genius.herewe.business.moment.domain.Moment;
+import com.genius.herewe.business.moment.repository.MomentMemberRepository;
 import com.genius.herewe.business.moment.repository.MomentRepository;
 import com.genius.herewe.core.global.exception.BusinessException;
 
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 public class MomentService {
 	private final EntityManager entityManager;
 	private final MomentRepository momentRepository;
+	private final MomentMemberRepository momentMemberRepository;
 
 	@Transactional
 	public Moment save(Moment moment) {
@@ -52,7 +53,7 @@ public class MomentService {
 		entityManager.flush();
 	}
 
-	public List<Moment> findAllJoined(List<Long> momentIds, LocalDateTime now) {
-		return momentRepository.findAllJoined(momentIds, now);
+	public Page<Moment> findAllJoinedMoments(Long userId, LocalDateTime now, Pageable pageable) {
+		return momentMemberRepository.findAllJoinedMoments(userId, now, pageable);
 	}
 }

--- a/src/main/java/com/genius/herewe/business/moment/service/MomentService.java
+++ b/src/main/java/com/genius/herewe/business/moment/service/MomentService.java
@@ -2,6 +2,9 @@ package com.genius.herewe.business.moment.service;
 
 import static com.genius.herewe.core.global.exception.ErrorCode.*;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -36,8 +39,8 @@ public class MomentService {
 			.orElseThrow(() -> new BusinessException(MOMENT_NOT_FOUND));
 	}
 
-	public Page<Moment> findAllByPaging(Long crewId, Pageable pageable) {
-		return momentRepository.findAllByPaging(crewId, pageable);
+	public Page<Moment> findAllInCrewByPaging(Long crewId, Pageable pageable) {
+		return momentRepository.findAllInCrewByPaging(crewId, pageable);
 	}
 
 	@Transactional
@@ -47,5 +50,9 @@ public class MomentService {
 
 	public void flushChanges() {
 		entityManager.flush();
+	}
+
+	public List<Moment> findAllJoined(List<Long> momentIds, LocalDateTime now) {
+		return momentRepository.findAllJoined(momentIds, now);
 	}
 }


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/83-inquiry-incoming-moments` -> `main`

</br>

### 🛠️ 변경 사항
> 메인페이지에서 다가오는 모먼트 목록을 조회하는 API를 개발합니다.
> 페이지네이션으로 구현하며, 디폴트 사이즈를 20개로 설정합니다.

#### ✅ 작업 상세 내용
- [x] 다가오는 모먼트 조회 API 구현 `GET /api/moment`
- [x] 만남 일자`meetAt`가 현재 일자와 가까운 순서대로 정렬해서 반환
- [x] N+1 문제를 해결하기 위해 다단계 쿼리 방법 사용: Moment → Crew → Location
- [x] swagger 정보 입력

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/22a91cc6-67ac-4a97-87b3-3f62ce128b91)


</br>

### 📚 연관된 이슈
#83

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
