### PR TITLE
[FEAT] 크루/모먼트 최대 참여인원 설정

### DIFF
--- a/src/main/java/com/genius/herewe/business/crew/domain/Crew.java
+++ b/src/main/java/com/genius/herewe/business/crew/domain/Crew.java
@@ -23,6 +23,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.validation.constraints.Max;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -67,6 +68,7 @@ public class Crew extends BaseTimeEntity implements FileHolder {
 	private String introduce;
 
 	@ColumnDefault("0")
+	@Max(value = 500, message = "크루 최대 참여 가능 인원은 500명입니다.")
 	private int participantCount;
 
 	@Builder

--- a/src/main/java/com/genius/herewe/business/invitation/facade/DefaultInvitationFacade.java
+++ b/src/main/java/com/genius/herewe/business/invitation/facade/DefaultInvitationFacade.java
@@ -31,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @Transactional(readOnly = true)
 public class DefaultInvitationFacade implements InvitationFacade {
+	private final int MAX_PARTICIPANT = 500;
 	private final String BASE_URL;
 	private final String INVITE_URL;
 	private final UserService userService;
@@ -40,10 +41,10 @@ public class DefaultInvitationFacade implements InvitationFacade {
 	private final MailManager mailManager;
 
 	public DefaultInvitationFacade(@Value("${url.base}") String BASE_URL,
-		@Value("${url.path.invite}") String INVITE_URL,
-		UserService userService, CrewService crewService,
-		CrewMemberService crewMemberService,
-		InvitationService invitationService, MailManager mailManager) {
+								   @Value("${url.path.invite}") String INVITE_URL,
+								   UserService userService, CrewService crewService,
+								   CrewMemberService crewMemberService,
+								   InvitationService invitationService, MailManager mailManager) {
 		this.BASE_URL = BASE_URL;
 		this.INVITE_URL = INVITE_URL;
 		this.userService = userService;
@@ -61,6 +62,9 @@ public class DefaultInvitationFacade implements InvitationFacade {
 			.orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
 		Crew crew = crewService.findById(invitationRequest.crewId());
 
+		if (crew.getParticipantCount() >= MAX_PARTICIPANT) {
+			throw new BusinessException(INVALID_CREW_CAPACITY);
+		}
 		if (crewMemberService.findOptional(user.getId(), crew.getId()).isPresent()) {
 			throw new BusinessException(ALREADY_JOINED_CREW);
 		}

--- a/src/main/java/com/genius/herewe/business/moment/domain/Moment.java
+++ b/src/main/java/com/genius/herewe/business/moment/domain/Moment.java
@@ -25,6 +25,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Version;
+import jakarta.validation.constraints.Max;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -61,8 +62,10 @@ public class Moment extends BaseTimeEntity implements FileHolder {
 	private String name;
 
 	@ColumnDefault("0")
+	@Max(value = 500, message = "모먼트 최대 참여 가능 인원 수는 500명입니다.")
 	private int participantCount;
 
+	@Max(value = 500, message = "모먼트 최대 참여 가능 인원 수는 500명입니다.")
 	private Integer capacity;
 
 	private LocalDateTime meetAt;

--- a/src/main/java/com/genius/herewe/business/moment/facade/DefaultMomentFacade.java
+++ b/src/main/java/com/genius/herewe/business/moment/facade/DefaultMomentFacade.java
@@ -265,7 +265,7 @@ public class DefaultMomentFacade implements MomentFacade {
 	}
 
 	private void validateCapacity(int capacity) {
-		if (capacity < 2) {
+		if (capacity < 2 || capacity > 500) {
 			throw new BusinessException(INVALID_MOMENT_CAPACITY);
 		}
 	}

--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -30,12 +30,13 @@ public enum ErrorCode {
 	CREW_JOIN_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 크루에 대한 참여 정보가 없습니다."),
 	ALREADY_JOINED_CREW(HttpStatus.BAD_REQUEST, "이미 참여한 크루입니다."),
 	CREW_MEMBERSHIP_REQUIRED(HttpStatus.FORBIDDEN, "크루 멤버에게만 허용된 작업입니다. 크루에 참여 후 재시도해주세요."),
+	INVALID_CREW_CAPACITY(HttpStatus.BAD_REQUEST, "CREW의 최대 참여 가능 인원은 500명 이하여야 합니다."),
 
 	INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "크루 초대 정보를 찾을 수 없습니다. 초대 정보를 다시 확인해주세요."),
 	INVITATION_EXPIRED(HttpStatus.BAD_REQUEST, "크루 초대가 만료되었습니다."),
 
 	MOMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 MOMENT를 찾을 수 없습니다."),
-	INVALID_MOMENT_CAPACITY(HttpStatus.BAD_REQUEST, "MOMENT의 최대 참여 가능 인원은 2명 이상이어야 합니다."),
+	INVALID_MOMENT_CAPACITY(HttpStatus.BAD_REQUEST, "MOMENT의 최대 참여 가능 인원은 2명 이상, 500명 이하여야 합니다."),
 	INVALID_MOMENT_DATE(HttpStatus.BAD_REQUEST, "만남일자(meetAt)/마감일자(closedAt)는 오늘보다 나중이어야 하며, 만남일자가 마감일자보다 더 이후여야 합니다."),
 	ALREADY_JOINED_MOMENT(HttpStatus.BAD_REQUEST, "이미 참여한 모먼트입니다."),
 	MOMENT_DEADLINE_EXPIRED(HttpStatus.BAD_REQUEST, "모먼트 참여 마감일자가 지났습니다. 모먼트 참여/참여 취소는 마감일자 이전까지 가능합니다."),


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/80-set-crew-moment-capacity` -> `main`

</br>

### 🛠️ 변경 사항
> 크루, 모먼트의 최대 참여 인원을 500명으로 설정합니다.

#### ✅ 작업 상세 내용
- [x] 크루 초대를 통한 참여 시, 최대 인원(500명)이 이미 차있을 때 INVALID_CREW_CAPACITY 예외 발생
- [x] 모먼트 생성 시, request body로 보낸 capacity가 500명 초과일 때 INVALID_MOMENT_CAPACITY 예외 발생
- [x] Crew, Moment 엔티티의 컬럼에 최대 값(500) 설정

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/57a248c7-7f75-474a-a350-f40782365931)


</br>

### 📚 연관된 이슈
#80

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
