### PR TITLE
[REFACTOR] 모먼트 상세 조회의 응답 DTO 변경

### DIFF
--- a/src/main/java/com/genius/herewe/business/moment/controller/MomentController.java
+++ b/src/main/java/com/genius/herewe/business/moment/controller/MomentController.java
@@ -63,7 +63,8 @@ public class MomentController implements MomentApi {
 
 	@GetMapping("/{momentId}")
 	public SingleResponse<MomentResponse> inquirySingleMoment(@HereWeUser User user, @PathVariable Long momentId) {
-		MomentResponse momentResponse = momentFacade.inquirySingle(user, momentId);
+		LocalDateTime now = LocalDateTime.now();
+		MomentResponse momentResponse = momentFacade.inquirySingle(user, momentId, now);
 		return new SingleResponse<>(HttpStatus.OK, momentResponse);
 	}
 

--- a/src/main/java/com/genius/herewe/business/moment/dto/MomentResponse.java
+++ b/src/main/java/com/genius/herewe/business/moment/dto/MomentResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import com.genius.herewe.business.location.search.dto.Place;
 import com.genius.herewe.business.moment.domain.Moment;
+import com.genius.herewe.business.moment.domain.ParticipantStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -13,8 +14,8 @@ import lombok.Builder;
 public record MomentResponse(
 	@Schema(description = "모먼트 식별자(PK)")
 	Long momentId,
-	@Schema(description = "사용자의 모먼트 참여 여부")
-	Boolean isJoined,
+	@Schema(description = "모먼트에 대한 사용자의 상태", example = "참여가능   or   참여중   or   마감")
+	String status,
 	@Schema(description = "모먼트 이름")
 	String name,
 	@Schema(description = "만나는 날짜")
@@ -29,10 +30,10 @@ public record MomentResponse(
 	LocalDateTime closedAt
 ) {
 
-	public static MomentResponse create(Moment moment, Place place, boolean isJoined) {
+	public static MomentResponse create(Moment moment, Place place, ParticipantStatus status) {
 		return MomentResponse.builder()
 			.momentId(moment.getId())
-			.isJoined(isJoined)
+			.status(status.getValue())
 			.name(moment.getName())
 			.meetAt(moment.getMeetAt())
 			.place(place)

--- a/src/main/java/com/genius/herewe/business/moment/facade/DefaultMomentFacade.java
+++ b/src/main/java/com/genius/herewe/business/moment/facade/DefaultMomentFacade.java
@@ -1,5 +1,6 @@
 package com.genius.herewe.business.moment.facade;
 
+import static com.genius.herewe.business.moment.domain.ParticipantStatus.*;
 import static com.genius.herewe.core.global.exception.ErrorCode.*;
 
 import java.time.LocalDateTime;
@@ -101,7 +102,7 @@ public class DefaultMomentFacade implements MomentFacade {
 
 	private ParticipantStatus getParticipantStatus(boolean isJoined, LocalDateTime closedAt, LocalDateTime now) {
 		if (isJoined) {
-			return ParticipantStatus.PARTICIPATING;
+			return PARTICIPATING;
 		}
 		if (now.isAfter(closedAt)) {
 			return ParticipantStatus.DEADLINE_PASSED;
@@ -110,7 +111,7 @@ public class DefaultMomentFacade implements MomentFacade {
 	}
 
 	@Override
-	public MomentResponse inquirySingle(User user, Long momentId) {
+	public MomentResponse inquirySingle(User user, Long momentId, LocalDateTime now) {
 		Moment moment = momentService.findById(momentId);
 
 		Optional<MomentMember> joinInfo = momentMemberService.findByJoinInfo(user.getId(), momentId);
@@ -119,7 +120,9 @@ public class DefaultMomentFacade implements MomentFacade {
 		Optional<Location> meetLocation = locationService.findMeetLocation(momentId);
 		Place place = Place.createFromOptional(meetLocation);
 
-		return MomentResponse.create(moment, place, isJoined);
+		ParticipantStatus status = getParticipantStatus(isJoined, moment.getClosedAt(), now);
+
+		return MomentResponse.create(moment, place, status);
 	}
 
 	@Override
@@ -146,7 +149,7 @@ public class DefaultMomentFacade implements MomentFacade {
 		Location location = locationService.saveFromPlace(momentRequest.place(), 1);
 		location.addMoment(moment);
 
-		return MomentResponse.create(moment, Place.create(location), true);
+		return MomentResponse.create(moment, Place.create(location), PARTICIPATING);
 	}
 
 	@Override
@@ -179,7 +182,7 @@ public class DefaultMomentFacade implements MomentFacade {
 								 });
 		});
 
-		return MomentResponse.create(moment, momentRequest.place(), true);
+		return MomentResponse.create(moment, momentRequest.place(), PARTICIPATING);
 	}
 
 	@Override
@@ -205,7 +208,7 @@ public class DefaultMomentFacade implements MomentFacade {
 		Optional<Location> optionalLocation = locationService.findMeetLocation(momentId);
 		Place place = Place.createFromOptional(optionalLocation);
 
-		return MomentResponse.create(moment, place, true);
+		return MomentResponse.create(moment, place, PARTICIPATING);
 	}
 
 	private void validateJoinCondition(Long userId, Moment moment, LocalDateTime now) {

--- a/src/main/java/com/genius/herewe/business/moment/facade/MomentFacade.java
+++ b/src/main/java/com/genius/herewe/business/moment/facade/MomentFacade.java
@@ -18,7 +18,7 @@ public interface MomentFacade {
 
 	Page<MomentPreviewResponse> inquiryList(Long userId, Long crewId, LocalDateTime now, Pageable pageable);
 
-	MomentResponse inquirySingle(User user, Long momentId);
+	MomentResponse inquirySingle(User user, Long momentId, LocalDateTime now);
 
 	MomentResponse create(Long userId, Long crewId, MomentRequest momentRequest);
 

--- a/src/test/java/com/genius/herewe/business/moment/facade/MomentFacadeTest.java
+++ b/src/test/java/com/genius/herewe/business/moment/facade/MomentFacadeTest.java
@@ -248,7 +248,7 @@ class MomentFacadeTest {
 
 				//then
 				assertThat(momentResponse).isNotNull();
-				assertThat(momentResponse.status()).isEqualTo(ParticipantStatus.PARTICIPATING);
+				assertThat(momentResponse.status()).isEqualTo(ParticipantStatus.PARTICIPATING.getValue());
 				assertThat(momentResponse.name()).isEqualTo(momentRequest.momentName());
 				assertThat(momentResponse.capacity()).isEqualTo(momentRequest.capacity());
 				assertThat(momentResponse.closedAt()).isEqualTo(momentRequest.closedAt());

--- a/src/test/java/com/genius/herewe/business/moment/facade/MomentFacadeTest.java
+++ b/src/test/java/com/genius/herewe/business/moment/facade/MomentFacadeTest.java
@@ -33,6 +33,7 @@ import com.genius.herewe.business.location.search.dto.Place;
 import com.genius.herewe.business.location.service.LocationService;
 import com.genius.herewe.business.moment.domain.Moment;
 import com.genius.herewe.business.moment.domain.MomentMember;
+import com.genius.herewe.business.moment.domain.ParticipantStatus;
 import com.genius.herewe.business.moment.dto.MomentRequest;
 import com.genius.herewe.business.moment.dto.MomentResponse;
 import com.genius.herewe.business.moment.fixture.MomentFixture;
@@ -80,7 +81,7 @@ class MomentFacadeTest {
 				return Stream.of(
 					Arguments.of(new MomentRequest("Test", null, place, 5, LocalDateTime.now()), "meetAt"),
 					Arguments.of(new MomentRequest("Test", LocalDateTime.now(), place, null, LocalDateTime.now()),
-						"capacity"),
+								 "capacity"),
 					Arguments.of(new MomentRequest("Test", LocalDateTime.now(), place, 5, null), "closedAt")
 				);
 			}
@@ -247,7 +248,7 @@ class MomentFacadeTest {
 
 				//then
 				assertThat(momentResponse).isNotNull();
-				assertThat(momentResponse.isJoined()).isTrue();
+				assertThat(momentResponse.status()).isEqualTo(ParticipantStatus.PARTICIPATING);
 				assertThat(momentResponse.name()).isEqualTo(momentRequest.momentName());
 				assertThat(momentResponse.capacity()).isEqualTo(momentRequest.capacity());
 				assertThat(momentResponse.closedAt()).isEqualTo(momentRequest.closedAt());


### PR DESCRIPTION
### PR 타입
□ 기능 추가
□ 기능 삭제
☑ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`refactor/87-moment-detail-response` -> `main`

</br>

### 🛠️ 변경 사항
> 모먼트 정보 상세 조회 `GET /api/moment/{momentId}`에서 `isJoined` 필드를 `ParticipantStatus` 필드로 변경합니다.
```
  "data": {
    "momentId": 1,
    "status": "참여중"   // 이전 버전 -> "isJoined": true, 
    "name": "text",
    "meetAt": "2025-04-01T07:04:20.131Z",
    "place": {
      "id": 1,
      "place_name": "text",
      "x": 1,
      "y": 1,
      "address_name": "text",
      "road_address_name": "text",
      "place_url": "text",
      "phone": "text"
    },
    "participantCount": 1,
    "capacity": 1,
    "closedAt": "2025-04-01T07:04:20.131Z"
  }
```

#### ✅ 작업 상세 내용
- [x] MomentResponse의 isJoined 필드를 참여 정보를 나타내는 ParticipantStatus 값으로 변경
    - [x] MomentFacade의 모먼트 상세 조회 메서드(`inquirySingle`)의 매개변수에 현재 일자 추가
    - [x] 참여중, 마감, 참여가능 중 1개 반환
- [x] 비지니스 로직 변경으로 인해 테스트 코드 변경

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/175cbdca-31bc-4f1c-a1a8-6dc17cc50502)

</br>

### 📚 연관된 이슈
#87

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
