### PR TITLE
[FEAT] 장소 삭제 API 개발

### DIFF
--- a/src/main/java/com/genius/herewe/business/location/controller/LocationApi.java
+++ b/src/main/java/com/genius/herewe/business/location/controller/LocationApi.java
@@ -11,6 +11,8 @@ import com.genius.herewe.core.global.response.CommonResponse;
 import com.genius.herewe.core.global.response.ExceptionResponse;
 import com.genius.herewe.core.global.response.SingleResponse;
 import com.genius.herewe.core.global.response.SlicingResponse;
+import com.genius.herewe.core.security.annotation.HereWeUser;
+import com.genius.herewe.core.user.domain.User;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -102,4 +104,85 @@ public interface LocationApi {
 		)
 	})
 	CommonResponse addPlace(@PathVariable Long momentId, @Valid @RequestBody LocationRequest locationRequest);
+
+	@Operation(summary = "등록되어 있는 장소 삭제", description = "모먼트에 등록되어 있는 장소 삭제")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "장소 삭제 성공"
+		),
+		@ApiResponse(
+			responseCode = "400",
+			description = """
+				1. query string으로 전달한 인덱스(삭제할 인덱스)가 유효하지 않을 때
+				2. 아직 예외 처리하지 못한 에러일 때 - 별도 처리 필요
+				""",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "1. query string으로 전달한 인덱스(삭제할 인덱스)가 유효하지 않을 때",
+						value = """
+							{
+								"resultCode": "400",
+								"code": "INVALID_LOCATION_INDEX",
+								"message": "유효하지 않은 위치 인덱스입니다."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "2. 아직 예외 처리하지 못한 에러일 때 - 별도 처리 필요",
+						value = """
+							{
+								"resultCode": "400",
+								"code": "UNEXPECTED_ERROR",
+								"message": "처리되지 않은 에러입니다. 추가 처리가 필요합니다."
+							}
+							"""
+					)
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = "사용자가 참여하지 않은 모먼트에서 장소 삭제 요청 시",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "사용자가 참여하지 않은 모먼트에서 장소 삭제 요청 시 (모먼트 참여 정보를 찾을 수 없을 때)",
+						value = """
+							{
+								"resultCode": "404",
+								"code": "MOMENT_PARTICIPATION_NOT_FOUND",
+								"message": "모먼트 참여 정보를 찾을 수 없습니다."
+							}
+							"""
+					)
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "409",
+			description = "동시성 문제로 인해 요청이 처리되지 못했을 때 - 재시도 필요",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "동시성 문제로 인해 요청이 처리되지 못했을 때",
+						value = """
+							{
+								"resultCode": "409",
+								"code": "CONCURRENT_MODIFICATION_EXCEPTION",
+								"message": "이 데이터는 다른 사용자에 의해 수정되었습니다. 다시 시도해주세요."
+							}
+							"""
+					)
+				}
+			)
+		)
+	})
+	CommonResponse deletePlace(@HereWeUser User user,
+							   @PathVariable Long momentId,
+							   @RequestParam("index") int locationIndex);
 }

--- a/src/main/java/com/genius/herewe/business/location/controller/LocationController.java
+++ b/src/main/java/com/genius/herewe/business/location/controller/LocationController.java
@@ -2,6 +2,7 @@ package com.genius.herewe.business.location.controller;
 
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +19,8 @@ import com.genius.herewe.business.location.search.dto.Place;
 import com.genius.herewe.core.global.response.CommonResponse;
 import com.genius.herewe.core.global.response.SingleResponse;
 import com.genius.herewe.core.global.response.SlicingResponse;
+import com.genius.herewe.core.security.annotation.HereWeUser;
+import com.genius.herewe.core.user.domain.User;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -31,8 +34,8 @@ public class LocationController implements LocationApi {
 
 	@GetMapping("/search/location")
 	public SlicingResponse<Place> search(@RequestParam("keyword") String keyword,
-		@RequestParam(defaultValue = "0") int page,
-		@RequestParam(defaultValue = "15") int size) {
+										 @RequestParam(defaultValue = "0") int page,
+										 @RequestParam(defaultValue = "15") int size) {
 
 		Slice<Place> places = kakaoSearchClient.searchByKeyword(keyword, size, page);
 
@@ -47,9 +50,18 @@ public class LocationController implements LocationApi {
 
 	@PostMapping("/location/{momentId}")
 	public CommonResponse addPlace(@PathVariable Long momentId,
-		@Valid @RequestBody LocationRequest locationRequest) {
+								   @Valid @RequestBody LocationRequest locationRequest) {
 
 		locationFacade.addPlace(momentId, locationRequest);
 		return CommonResponse.created();
+	}
+
+	@DeleteMapping("/location/{momentId}")
+	public CommonResponse deletePlace(@HereWeUser User user,
+									  @PathVariable Long momentId,
+									  @RequestParam("index") int locationIndex) {
+
+		locationFacade.deletePlace(user.getId(), momentId, locationIndex);
+		return CommonResponse.ok();
 	}
 }

--- a/src/main/java/com/genius/herewe/business/location/facade/LocationFacade.java
+++ b/src/main/java/com/genius/herewe/business/location/facade/LocationFacade.java
@@ -8,4 +8,6 @@ public interface LocationFacade {
 	Place addPlace(Long momentId, LocationRequest locationRequest);
 
 	PlaceResponse inquiryAll(Long momentId);
+
+	void deletePlace(Long userId, Long momentId, int locationIndex);
 }

--- a/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
+++ b/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
@@ -21,7 +21,7 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
 	@Query("SELECT l FROM Location l WHERE l.locationIndex = 1 AND l.moment.id IN :momentIds")
 	List<Location> findMeetingLocationsByIds(@Param("momentIds") List<Long> momentIds);
 
-	@Modifying
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
 	@Query("""
 		UPDATE Location l
 		SET l.locationIndex = l.locationIndex - 1

--- a/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
+++ b/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,5 +19,15 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
 	List<Location> findAllInMoment(@Param("momentId") Long momentId);
 
 	@Query("SELECT l FROM Location l WHERE l.locationIndex = 1 AND l.moment.id IN :momentIds")
-	List<Location> findMeetingLocationsByIds(List<Long> momentIds);
+	List<Location> findMeetingLocationsByIds(@Param("momentIds") List<Long> momentIds);
+
+	@Modifying
+	@Query("""
+		UPDATE Location l
+		SET l.locationIndex = l.locationIndex - 1
+		WHERE l.moment.id = :momentId AND l.locationIndex > :thresholdIndex AND l.moment.version = :momentVersion
+		""")
+	int bulkDecreaseIndexes(@Param("momentId") Long momentId,
+							@Param("thresholdIndex") int thresholdIndex,
+							@Param("momentVersion") Long momentVersion);
 }

--- a/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
+++ b/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
@@ -30,4 +30,8 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
 	int bulkDecreaseIndexes(@Param("momentId") Long momentId,
 							@Param("thresholdIndex") int thresholdIndex,
 							@Param("momentVersion") Long momentVersion);
+
+	@Query("SELECT MAX(l.locationIndex) FROM Location l WHERE l.moment.id = :momentId")
+	int findLastIndexForMoment(@Param("momentId") Long momentId);
+
 }

--- a/src/main/java/com/genius/herewe/business/location/service/LocationService.java
+++ b/src/main/java/com/genius/herewe/business/location/service/LocationService.java
@@ -32,6 +32,7 @@ public class LocationService {
 	}
 
 	public Optional<Location> findByIndex(Long momentId, int locationIndex) {
+		Optional<Location> byLocationIndex = locationRepository.findByLocationIndex(momentId, locationIndex);
 		return locationRepository.findByLocationIndex(momentId, locationIndex);
 	}
 
@@ -50,6 +51,10 @@ public class LocationService {
 				location -> location.getMoment().getId(),
 				location -> location
 			));
+	}
+
+	public int findLastIndexForMoment(Long momentId) {
+		return locationRepository.findLastIndexForMoment(momentId);
 	}
 
 	@Transactional

--- a/src/main/java/com/genius/herewe/business/location/service/LocationService.java
+++ b/src/main/java/com/genius/herewe/business/location/service/LocationService.java
@@ -51,4 +51,14 @@ public class LocationService {
 				location -> location
 			));
 	}
+
+	@Transactional
+	public int bulkDecreaseIndexes(Long momentId, int locationIndex, Long momentVersion) {
+		return locationRepository.bulkDecreaseIndexes(momentId, locationIndex, momentVersion);
+	}
+
+	@Transactional
+	public void delete(Location location) {
+		locationRepository.delete(location);
+	}
 }

--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -42,6 +42,9 @@ public enum ErrorCode {
 	MOMENT_DEADLINE_EXPIRED(HttpStatus.BAD_REQUEST, "모먼트 참여 마감일자가 지났습니다. 모먼트 참여/참여 취소는 마감일자 이전까지 가능합니다."),
 	MOMENT_CAPACITY_FULL(HttpStatus.BAD_REQUEST, "참여 인원이 최대 정원에 도달했습니다."),
 
+	MOMENT_PARTICIPATION_NOT_FOUND(HttpStatus.NOT_FOUND, "모먼트 참여 정보를 찾을 수 없습니다."),
+
+	LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 모먼트에 해당 인덱스의 장소가 존재하지 않습니다."),
 	LOCATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 순서의 장소가 이미 추가되었습니다. 잠시 후 다시 시도해주세요."),
 	LOCATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "장소는 최대 100개까지 등록할 수 있습니다."),
 

--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+	UNEXPECTED_ERROR(HttpStatus.BAD_REQUEST, "처리되지 않은 에러입니다. 추가 처리가 필요합니다."),
+
 	CONCURRENT_MODIFICATION_EXCEPTION(HttpStatus.CONFLICT, "이 데이터는 다른 사용자에 의해 수정되었습니다. 다시 시도해주세요."),
 	REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST, "해당 항목은 필수 항목입니다. 입력 값을 확인해주세요."),
 	VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "데이터 전달 관련 유효성 검사에 실패했습니다."),

--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
 	LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 모먼트에 해당 인덱스의 장소가 존재하지 않습니다."),
 	LOCATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 순서의 장소가 이미 추가되었습니다. 잠시 후 다시 시도해주세요."),
 	LOCATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "장소는 최대 100개까지 등록할 수 있습니다."),
+	INVALID_LOCATION_INDEX(HttpStatus.BAD_REQUEST, "유효하지 않은 위치 인덱스입니다."),
 
 	UNAUTHORIZED_ISSUE(HttpStatus.UNAUTHORIZED, "회원가입이 되어 있지 않은 사용자의 경우 JWT를 발급할 수 없습니다."),
 	JWT_NOT_VALID(HttpStatus.UNAUTHORIZED, "JWT가 유효하지 않습니다."),

--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -46,7 +46,6 @@ public enum ErrorCode {
 
 	MOMENT_PARTICIPATION_NOT_FOUND(HttpStatus.NOT_FOUND, "모먼트 참여 정보를 찾을 수 없습니다."),
 
-	LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 모먼트에 해당 인덱스의 장소가 존재하지 않습니다."),
 	LOCATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 순서의 장소가 이미 추가되었습니다. 잠시 후 다시 시도해주세요."),
 	LOCATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "장소는 최대 100개까지 등록할 수 있습니다."),
 	INVALID_LOCATION_INDEX(HttpStatus.BAD_REQUEST, "유효하지 않은 위치 인덱스입니다."),


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/86-delete-place` -> `main`

</br>

### 🛠️ 변경 사항
> 모먼트 상세 페이지에서 조회한 장소들 중, 하나를 삭제하는 API를 개발합니다.

#### ✅ 작업 상세 내용
- [x] 장소 삭제 API `DELETE /api/location/{momentId}?index={index}`
    - [x] 요청한 인덱스가 범위 내 인덱스 여부인지 판단 후, 아니라면 INVALID_LOCATION_INDEX 예외 발생
    - [x] 인덱스 범위 검사 후, 인덱스를 찾을 수 없는 경우에는 동시성 문제이므로, CONCURRENT_MODIFICATION_EXCEPTION 예외를 발생시키도록 설정
- [x] 성능 이슈로 인해 다른 장소들의 인덱스 변경 시, UPDATE문을 통해 bulk 연산 수행
    - [x] @Modifying의 낙관적 락 우회 이슈로 인해, UPDATE 쿼리에서 직접 moment 버전 확인하도록 변경
    - [x] 업데이트된 row의 수가 0인 경우 버전 불일치로 인해 제대로 된 처리가 되지 않았다는 의미이므로CONCURRENT_MODIFICATION_EXCEPTION 예외 발생
        - [x] 삭제하고자 하는 인덱스가 마지막 인덱스일 때에는 검사 X
- [x] swagger 정보 입력

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/4288478c-3ad2-4882-9642-918247993fe5)

</br>

### 📚 연관된 이슈
#86

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
