### PR TITLE
[FEAT] 장소 등록 API에 참여 사용자 검증 및 index 필드 자동화 구현

### DIFF
--- a/src/main/java/com/genius/herewe/business/location/LocationRequest.java
+++ b/src/main/java/com/genius/herewe/business/location/LocationRequest.java
@@ -7,8 +7,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "추가 할 장소 DTO")
 public record LocationRequest(
 	@Schema(description = "장소 정보")
-	Place place,
-	@Schema(description = "추가하는 장소가 부여받을 인덱스 번호")
-	int locationIndex
+	Place place
 ) {
 }

--- a/src/main/java/com/genius/herewe/business/location/controller/LocationApi.java
+++ b/src/main/java/com/genius/herewe/business/location/controller/LocationApi.java
@@ -103,7 +103,9 @@ public interface LocationApi {
 			)
 		)
 	})
-	CommonResponse addPlace(@PathVariable Long momentId, @Valid @RequestBody LocationRequest locationRequest);
+	CommonResponse addPlace(@HereWeUser User user,
+							@PathVariable Long momentId,
+							@Valid @RequestBody LocationRequest locationRequest);
 
 	@Operation(summary = "등록되어 있는 장소 삭제", description = "모먼트에 등록되어 있는 장소 삭제")
 	@ApiResponses({

--- a/src/main/java/com/genius/herewe/business/location/controller/LocationController.java
+++ b/src/main/java/com/genius/herewe/business/location/controller/LocationController.java
@@ -49,10 +49,11 @@ public class LocationController implements LocationApi {
 	}
 
 	@PostMapping("/location/{momentId}")
-	public CommonResponse addPlace(@PathVariable Long momentId,
+	public CommonResponse addPlace(@HereWeUser User user,
+								   @PathVariable Long momentId,
 								   @Valid @RequestBody LocationRequest locationRequest) {
 
-		locationFacade.addPlace(momentId, locationRequest);
+		locationFacade.addPlace(user.getId(), momentId, locationRequest);
 		return CommonResponse.created();
 	}
 

--- a/src/main/java/com/genius/herewe/business/location/facade/DefaultLocationFacade.java
+++ b/src/main/java/com/genius/herewe/business/location/facade/DefaultLocationFacade.java
@@ -36,7 +36,10 @@ public class DefaultLocationFacade implements LocationFacade {
 
 	@Override
 	@Transactional
-	public Place addPlace(Long momentId, LocationRequest locationRequest) {
+	public Place addPlace(Long userId, Long momentId, LocationRequest locationRequest) {
+		momentMemberService.findByJoinInfo(userId, momentId)
+			.orElseThrow(() -> new BusinessException(MOMENT_PARTICIPATION_NOT_FOUND));
+
 		return retryHandler.executeWithRetry(
 			() -> executeAddPlace(momentId, locationRequest)
 		);

--- a/src/main/java/com/genius/herewe/business/location/facade/DefaultLocationFacade.java
+++ b/src/main/java/com/genius/herewe/business/location/facade/DefaultLocationFacade.java
@@ -4,8 +4,6 @@ import static com.genius.herewe.core.global.exception.ErrorCode.*;
 
 import java.util.List;
 
-import org.hibernate.StaleStateException;
-import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +12,7 @@ import com.genius.herewe.business.location.LocationRequest;
 import com.genius.herewe.business.location.domain.Location;
 import com.genius.herewe.business.location.dto.LocationInfo;
 import com.genius.herewe.business.location.dto.PlaceResponse;
+import com.genius.herewe.business.location.handler.RetryHandler;
 import com.genius.herewe.business.location.search.dto.Place;
 import com.genius.herewe.business.location.service.LocationService;
 import com.genius.herewe.business.moment.domain.Moment;
@@ -30,15 +29,21 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class DefaultLocationFacade implements LocationFacade {
-	private final int MAX_RETRIES = 3;
-
 	private final MomentService momentService;
 	private final MomentMemberService momentMemberService;
 	private final LocationService locationService;
+	private final RetryHandler retryHandler;
 
 	@Override
 	@Transactional
 	public Place addPlace(Long momentId, LocationRequest locationRequest) {
+		return retryHandler.executeWithRetry(
+			() -> executeAddPlace(momentId, locationRequest)
+		);
+	}
+
+	@Transactional
+	public Place executeAddPlace(Long momentId, LocationRequest locationRequest) {
 		try {
 			Place place = locationRequest.place();
 
@@ -49,7 +54,7 @@ public class DefaultLocationFacade implements LocationFacade {
 			}
 
 			Moment moment = momentService.findByIdWithOptimisticLock(momentId);
-			
+
 			Location location = Location.createFromPlace(place, nextIndex);
 			location.addMoment(moment);
 			locationService.save(location);
@@ -80,63 +85,10 @@ public class DefaultLocationFacade implements LocationFacade {
 	@Override
 	@Transactional
 	public void deletePlace(Long userId, Long momentId, int locationIndex) {
-		int retryCount = 0;
-		while (retryCount < MAX_RETRIES) {
-			try {
-				// 이 밑에 함수만 다른걸 쓸거임
-				executeDeletePlace(userId, momentId, locationIndex);
-				return;
-			} catch (Exception e) {
-				retryCount++;
-				if (shouldRetry(e) && retryCount < MAX_RETRIES) {
-					logRetryAttempt(retryCount, momentId, locationIndex, e);
-					applyBackoff(retryCount);
-				} else {
-					throw translateException(e);
-				}
-			}
-		}
-	}
-
-	private boolean shouldRetry(Exception e) {
-		boolean isDbException = e instanceof OptimisticLockException
-			|| e instanceof DataAccessException
-			|| e instanceof StaleStateException;
-
-		boolean isRetryException = (e instanceof BusinessException) &&
-			(((BusinessException)e).getErrorCode() == CONCURRENT_MODIFICATION_EXCEPTION);
-
-		boolean hasRetryCause = e.getCause() != null && (
-			e.getCause() instanceof DataAccessException ||
-				(e.getCause().getMessage() != null &&
-					e.getCause().getMessage().contains("Deadlock"))
-		);
-
-		return isDbException || isRetryException || hasRetryCause;
-	}
-
-	private void applyBackoff(int retryCount) {
-		try {
-			long delay = (long)(100 * Math.pow(2, retryCount - 1));
-			Thread.sleep(delay);
-		} catch (InterruptedException ie) {
-			Thread.currentThread().interrupt();
-		}
-	}
-
-	private void logRetryAttempt(int retryCount, Long momentId, int locationIndex, Exception e) {
-		log.warn("Retry attempt {}/{} for deleting place: momentId={}, locationIndex={}, error={}",
-				 retryCount, MAX_RETRIES, momentId, locationIndex, e.getMessage());
-	}
-
-	private RuntimeException translateException(Exception e) {
-		if (e instanceof BusinessException) {
-			return (BusinessException)e;
-		} else if (e instanceof OptimisticLockException || e instanceof DataAccessException) {
-			return new BusinessException(CONCURRENT_MODIFICATION_EXCEPTION, e);
-		} else {
-			return new BusinessException(UNEXPECTED_ERROR, e);
-		}
+		retryHandler.executeWithRetry(() -> {
+			executeDeletePlace(userId, momentId, locationIndex);
+			return null;
+		});
 	}
 
 	@Transactional

--- a/src/main/java/com/genius/herewe/business/location/facade/LocationFacade.java
+++ b/src/main/java/com/genius/herewe/business/location/facade/LocationFacade.java
@@ -5,7 +5,7 @@ import com.genius.herewe.business.location.dto.PlaceResponse;
 import com.genius.herewe.business.location.search.dto.Place;
 
 public interface LocationFacade {
-	Place addPlace(Long momentId, LocationRequest locationRequest);
+	Place addPlace(Long userId, Long momentId, LocationRequest locationRequest);
 
 	PlaceResponse inquiryAll(Long momentId);
 

--- a/src/main/java/com/genius/herewe/business/location/handler/RetryHandler.java
+++ b/src/main/java/com/genius/herewe/business/location/handler/RetryHandler.java
@@ -1,0 +1,76 @@
+package com.genius.herewe.business.location.handler;
+
+import static com.genius.herewe.core.global.exception.ErrorCode.*;
+
+import org.hibernate.StaleStateException;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Component;
+
+import com.genius.herewe.core.global.exception.BusinessException;
+
+import jakarta.persistence.OptimisticLockException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class RetryHandler {
+	private static final int MAX_RETRIES = 3;
+
+	public <T> T executeWithRetry(RetryableOperation<T> operation) {
+		int retryCount = 0;
+		while (retryCount < MAX_RETRIES) {
+			try {
+				return operation.execute();
+			} catch (Exception e) {
+				retryCount++;
+				if (shouldRetry(e) && retryCount < MAX_RETRIES) {
+					logRetryAttempt(retryCount, e);
+					applyBackoff(retryCount);
+				} else {
+					throw translateException(e);
+				}
+			}
+		}
+		throw new BusinessException(UNEXPECTED_ERROR);
+	}
+
+	private boolean shouldRetry(Exception e) {
+		boolean isDbException = e instanceof OptimisticLockException
+			|| e instanceof DataAccessException
+			|| e instanceof StaleStateException;
+
+		boolean isRetryException = (e instanceof BusinessException) &&
+			(((BusinessException)e).getErrorCode() == CONCURRENT_MODIFICATION_EXCEPTION);
+
+		boolean hasRetryCause = e.getCause() != null && (
+			e.getCause() instanceof DataAccessException ||
+				(e.getCause().getMessage() != null &&
+					e.getCause().getMessage().contains("Deadlock"))
+		);
+
+		return isDbException || isRetryException || hasRetryCause;
+	}
+
+	private void applyBackoff(int retryCount) {
+		try {
+			long delay = (long)(100 * Math.pow(2, retryCount - 1));
+			Thread.sleep(delay);
+		} catch (InterruptedException ie) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	private void logRetryAttempt(int retryCount, Exception e) {
+		log.warn("Retry attempt {}/{} : error={}", retryCount, MAX_RETRIES, e.getMessage());
+	}
+
+	private RuntimeException translateException(Exception e) {
+		if (e instanceof BusinessException) {
+			return (BusinessException)e;
+		} else if (e instanceof OptimisticLockException || e instanceof DataAccessException) {
+			return new BusinessException(CONCURRENT_MODIFICATION_EXCEPTION, e);
+		} else {
+			return new BusinessException(UNEXPECTED_ERROR, e);
+		}
+	}
+}

--- a/src/main/java/com/genius/herewe/business/location/handler/RetryableOperation.java
+++ b/src/main/java/com/genius/herewe/business/location/handler/RetryableOperation.java
@@ -1,0 +1,6 @@
+package com.genius.herewe.business.location.handler;
+
+@FunctionalInterface
+public interface RetryableOperation<T> {
+	T execute() throws Exception;
+}

--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -44,7 +44,7 @@ public enum ErrorCode {
 	MOMENT_DEADLINE_EXPIRED(HttpStatus.BAD_REQUEST, "모먼트 참여 마감일자가 지났습니다. 모먼트 참여/참여 취소는 마감일자 이전까지 가능합니다."),
 	MOMENT_CAPACITY_FULL(HttpStatus.BAD_REQUEST, "참여 인원이 최대 정원에 도달했습니다."),
 
-	MOMENT_PARTICIPATION_NOT_FOUND(HttpStatus.NOT_FOUND, "모먼트 참여 정보를 찾을 수 없습니다."),
+	MOMENT_PARTICIPATION_NOT_FOUND(HttpStatus.NOT_FOUND, "모먼트 참여 정보를 찾을 수 없습니다. 모먼트 참여자가 아닙니다."),
 
 	LOCATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 순서의 장소가 이미 추가되었습니다. 잠시 후 다시 시도해주세요."),
 	LOCATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "장소는 최대 100개까지 등록할 수 있습니다."),


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/place-api-improvements` -> `main`

</br>

### 🛠️ 변경 사항
> 1. 장소 등록 API에 예외 추가 처리
> 2. 장소 등록 API 비지니스 로직 변경
> AS-IS: request body에 이번에 등록해야 할 index를 전달받아서 처리
> TO-BE: request body로 index를 전달하지 않고 


#### ✅ 작업 상세 내용
- [x] 사용자가 모먼트에 참여한 사용자인지 검증하는 로직 추가
    - [x] 모먼트 참여자가 아닌 경우 `MOMENT_PARTICIPATION_NOT_FOUND` 예외 발생
- [x] 장소 등록 Request body에서 index 필드 삭제 → 백엔드에서 알아서 추가하도록 설정
- [x] 재시도 로직을 별도의 클래스로 분리 (RetryHandler, RetryableOperation)
    - [x] 장소 추가 API에 재시도 로직 적용
- [x] curl을 이용해 장소 삭제/ 장소삭제 + 등록 병렬 요청 시 동시성 예외가 발생하는지 확인

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/00e66497-089a-4090-90ba-fc41f7ef78f8)

</br>

### 📚 연관된 이슈
#77

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
