### PR TITLE
[FEAT] 만남 장소 순서 수정 API 개발

### DIFF
--- a/src/main/java/com/genius/herewe/business/location/controller/LocationApi.java
+++ b/src/main/java/com/genius/herewe/business/location/controller/LocationApi.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.genius.herewe.business.location.LocationRequest;
+import com.genius.herewe.business.location.dto.PlaceOrderRequest;
 import com.genius.herewe.business.location.dto.PlaceResponse;
 import com.genius.herewe.business.location.search.dto.Place;
 import com.genius.herewe.core.global.response.CommonResponse;
@@ -187,4 +188,76 @@ public interface LocationApi {
 	CommonResponse deletePlace(@HereWeUser User user,
 							   @PathVariable Long momentId,
 							   @RequestParam("index") int locationIndex);
+
+	@Operation(summary = "장소 순서 변경", description = "등록된 장소의 순서를 변경")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "장소 순서 변경 성공"
+		),
+		@ApiResponse(
+			responseCode = "400",
+			description = """
+				request body에 담긴 인덱스 정보가 유효하지 않을 때
+				1) originalIndex(원래 위치)가 1~최대 값 범위를 벗어나있을 때
+				2) newIndex(변경하고자 하는 위치)가 1~최대 값 범위를 벗어나있을 때
+				""",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "request body에 담긴 인덱스 정보가 유효하지 않을 때",
+						value = """
+							{
+								"resultCode": "400",
+								"code": "INVALID_LOCATION_INDEX",
+								"message": "유효하지 않은 위치 인덱스입니다."
+							}
+							"""
+					)
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = "모먼트에 참여하지 않은 사용자가 요청했을 때. 즉, 모먼트 참여 정보를 찾을 수 없을 때",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "모먼트 참여 정보를 찾을 수 없을 때",
+						value = """
+							{
+								"resultCode": "404",
+								"code": "MOMENT_PARTICIPATION_NOT_FOUND",
+								"message": "모먼트 참여 정보를 찾을 수 없습니다. 모먼트 참여자가 아닙니다."
+							}
+							"""
+					)
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "409",
+			description = "동시성 문제로 인해 요청이 처리되지 못했을 때 - 재시도 필요",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "동시성 문제로 인해 요청이 처리되지 못했을 때 - 재시도 필요",
+						value = """
+							{
+								"resultCode": "409",
+								"code": "CONCURRENT_MODIFICATION_EXCEPTION",
+								"message": "이 데이터는 다른 사용자에 의해 수정되었습니다. 다시 시도해주세요."
+							}
+							"""
+					)
+				}
+			)
+		)
+	})
+	CommonResponse updateOrder(@HereWeUser User user,
+							   @PathVariable Long momentId,
+							   @RequestBody PlaceOrderRequest orderRequest);
 }

--- a/src/main/java/com/genius/herewe/business/location/controller/LocationController.java
+++ b/src/main/java/com/genius/herewe/business/location/controller/LocationController.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.genius.herewe.business.location.LocationRequest;
+import com.genius.herewe.business.location.dto.PlaceOrderRequest;
 import com.genius.herewe.business.location.dto.PlaceResponse;
 import com.genius.herewe.business.location.facade.LocationFacade;
 import com.genius.herewe.business.location.search.client.KakaoSearchClient;
@@ -63,6 +65,15 @@ public class LocationController implements LocationApi {
 									  @RequestParam("index") int locationIndex) {
 
 		locationFacade.deletePlace(user.getId(), momentId, locationIndex);
+		return CommonResponse.ok();
+	}
+
+	@PatchMapping("/location/{momentId}")
+	public CommonResponse updateOrder(@HereWeUser User user,
+									  @PathVariable Long momentId,
+									  @RequestBody PlaceOrderRequest orderRequest) {
+		
+		locationFacade.updateOrder(user.getId(), momentId, orderRequest);
 		return CommonResponse.ok();
 	}
 }

--- a/src/main/java/com/genius/herewe/business/location/domain/Location.java
+++ b/src/main/java/com/genius/herewe/business/location/domain/Location.java
@@ -65,9 +65,9 @@ public class Location {
 
 	@Builder
 	public Location(int locationIndex, Long placeId, String name, String address, String roadAddress, String url,
-		Double x,
-		Double y,
-		String phone) {
+					Double x,
+					Double y,
+					String phone) {
 		this.locationIndex = locationIndex;
 		this.placeId = placeId;
 		this.name = name;

--- a/src/main/java/com/genius/herewe/business/location/dto/PlaceOrderRequest.java
+++ b/src/main/java/com/genius/herewe/business/location/dto/PlaceOrderRequest.java
@@ -1,0 +1,10 @@
+package com.genius.herewe.business.location.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PlaceOrderRequest(
+	int originalIndex,
+	int newIndex
+) {
+}

--- a/src/main/java/com/genius/herewe/business/location/facade/DefaultLocationFacade.java
+++ b/src/main/java/com/genius/herewe/business/location/facade/DefaultLocationFacade.java
@@ -147,7 +147,7 @@ public class DefaultLocationFacade implements LocationFacade {
 		Moment moment = momentService.findByIdWithOptimisticLock(momentId);
 		Long momentVersion = moment.getVersion();
 
-		locationService.updateLocationIndexToTemporary(momentId, originalIndex, -1, momentVersion);
+		locationService.repositionIndex(momentId, originalIndex, -1, momentVersion);
 
 		if (originalIndex < newIndex) {
 			locationService.invertIndexesForDecrement(momentId, originalIndex, newIndex, momentVersion);
@@ -156,7 +156,7 @@ public class DefaultLocationFacade implements LocationFacade {
 			locationService.invertIndexesForIncrement(momentId, newIndex, originalIndex, momentVersion);
 			locationService.applyIncrementToInverted(momentId, -originalIndex, momentVersion);
 		}
-		locationService.updateLocationIndexToTemporary(momentId, -1, newIndex, momentVersion);
+		locationService.repositionIndex(momentId, -1, newIndex, momentVersion);
 
 		moment = momentService.findByIdWithOptimisticLock(momentId);
 		moment.updateLastModifiedTime();

--- a/src/main/java/com/genius/herewe/business/location/facade/LocationFacade.java
+++ b/src/main/java/com/genius/herewe/business/location/facade/LocationFacade.java
@@ -1,6 +1,7 @@
 package com.genius.herewe.business.location.facade;
 
 import com.genius.herewe.business.location.LocationRequest;
+import com.genius.herewe.business.location.dto.PlaceOrderRequest;
 import com.genius.herewe.business.location.dto.PlaceResponse;
 import com.genius.herewe.business.location.search.dto.Place;
 
@@ -10,4 +11,6 @@ public interface LocationFacade {
 	PlaceResponse inquiryAll(Long momentId);
 
 	void deletePlace(Long userId, Long momentId, int locationIndex);
+
+	void updateOrder(Long userId, Long momentId, PlaceOrderRequest orderRequest);
 }

--- a/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
+++ b/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
@@ -34,4 +34,61 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
 	@Query("SELECT MAX(l.locationIndex) FROM Location l WHERE l.moment.id = :momentId")
 	int findLastIndexForMoment(@Param("momentId") Long momentId);
 
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
+	@Query("""
+		UPDATE Location l
+		SET l.locationIndex = -l.locationIndex
+		WHERE l.moment.id = :momentId AND l.moment.version = :momentVersion
+		AND l.locationIndex > :lowerBound AND l.locationIndex <= :upperBound
+		""")
+	int invertIndexesForDecrement(@Param("momentId") Long momentId,
+								  @Param("lowerBound") int lowerBound,
+								  @Param("upperBound") int upperBound,
+								  @Param("momentVersion") Long momentVersion);
+
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
+	@Query("""
+		UPDATE Location l
+		SET l.locationIndex = -l.locationIndex
+		WHERE l.moment.id = :momentId AND l.moment.version = :momentVersion
+		AND l.locationIndex >= :lowerBound AND l.locationIndex < :upperBound
+		""")
+	int invertIndexesForIncrement(@Param("momentId") Long momentId,
+								  @Param("lowerBound") int lowerBound,
+								  @Param("upperBound") int upperBound,
+								  @Param("momentVersion") Long momentVersion);
+
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
+	@Query("""
+		UPDATE Location l
+		SET l.locationIndex = (-l.locationIndex - 1)
+		WHERE l.moment.id = :momentId AND l.moment.version = :momentVersion
+		AND l.locationIndex < -1 AND l.locationIndex >= :lowerThreshold
+		""")
+	int applyDecrementToInverted(@Param("momentId") Long momentId,
+								 @Param("lowerThreshold") int lowerThreshold,
+								 @Param("momentVersion") Long momentVersion);
+
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
+	@Query("""
+		UPDATE Location l
+		SET l.locationIndex = (-l.locationIndex + 1)
+		WHERE l.moment.id = :momentId AND l.moment.version = :momentVersion
+		AND l.locationIndex < -1 AND l.locationIndex >= :lowerThreshold
+		""")
+	int applyIncrementToInverted(@Param("momentId") Long momentId,
+								 @Param("lowerThreshold") int lowerThreshold,
+								 @Param("momentVersion") Long momentVersion);
+
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
+	@Query("""
+		UPDATE Location l
+		SET l.locationIndex = :newIndex
+		WHERE l.moment.id = :momentId AND l.moment.version = :momentVersion
+		AND l.locationIndex = :originalIndex
+		""")
+	int updateLocationIndexToTemporary(@Param("momentId") Long momentId,
+									   @Param("originalIndex") int originalIndex,
+									   @Param("newIndex") int newIndex,
+									   @Param("momentVersion") Long momentVersion);
 }

--- a/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
+++ b/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
@@ -21,16 +21,6 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
 	@Query("SELECT l FROM Location l WHERE l.locationIndex = 1 AND l.moment.id IN :momentIds")
 	List<Location> findMeetingLocationsByIds(@Param("momentIds") List<Long> momentIds);
 
-	@Modifying(flushAutomatically = true, clearAutomatically = true)
-	@Query("""
-		UPDATE Location l
-		SET l.locationIndex = l.locationIndex - 1
-		WHERE l.moment.id = :momentId AND l.locationIndex > :thresholdIndex AND l.moment.version = :momentVersion
-		""")
-	int bulkDecreaseIndexes(@Param("momentId") Long momentId,
-							@Param("thresholdIndex") int thresholdIndex,
-							@Param("momentVersion") Long momentVersion);
-
 	@Query("SELECT MAX(l.locationIndex) FROM Location l WHERE l.moment.id = :momentId")
 	int findLastIndexForMoment(@Param("momentId") Long momentId);
 

--- a/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
+++ b/src/main/java/com/genius/herewe/business/location/repository/LocationRepository.java
@@ -87,8 +87,8 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
 		WHERE l.moment.id = :momentId AND l.moment.version = :momentVersion
 		AND l.locationIndex = :originalIndex
 		""")
-	int updateLocationIndexToTemporary(@Param("momentId") Long momentId,
-									   @Param("originalIndex") int originalIndex,
-									   @Param("newIndex") int newIndex,
-									   @Param("momentVersion") Long momentVersion);
+	int repositionIndex(@Param("momentId") Long momentId,
+						@Param("originalIndex") int originalIndex,
+						@Param("newIndex") int newIndex,
+						@Param("momentVersion") Long momentVersion);
 }

--- a/src/main/java/com/genius/herewe/business/location/service/LocationService.java
+++ b/src/main/java/com/genius/herewe/business/location/service/LocationService.java
@@ -32,7 +32,6 @@ public class LocationService {
 	}
 
 	public Optional<Location> findByIndex(Long momentId, int locationIndex) {
-		Optional<Location> byLocationIndex = locationRepository.findByLocationIndex(momentId, locationIndex);
 		return locationRepository.findByLocationIndex(momentId, locationIndex);
 	}
 
@@ -60,6 +59,31 @@ public class LocationService {
 	@Transactional
 	public int bulkDecreaseIndexes(Long momentId, int locationIndex, Long momentVersion) {
 		return locationRepository.bulkDecreaseIndexes(momentId, locationIndex, momentVersion);
+	}
+
+	@Transactional
+	public int invertIndexesForDecrement(Long momentId, int lowerBound, int upperBound, Long momentVersion) {
+		return locationRepository.invertIndexesForDecrement(momentId, lowerBound, upperBound, momentVersion);
+	}
+
+	@Transactional
+	public int applyDecrementToInverted(Long momentId, int lowerThreshold, Long momentVersion) {
+		return locationRepository.applyDecrementToInverted(momentId, lowerThreshold, momentVersion);
+	}
+
+	@Transactional
+	public int applyIncrementToInverted(Long momentId, int lowerThreshold, Long momentVersion) {
+		return locationRepository.applyIncrementToInverted(momentId, lowerThreshold, momentVersion);
+	}
+
+	@Transactional
+	public int invertIndexesForIncrement(Long momentId, int lowerBound, int upperBound, Long momentVersion) {
+		return locationRepository.invertIndexesForIncrement(momentId, lowerBound, upperBound, momentVersion);
+	}
+
+	@Transactional
+	public int updateLocationIndexToTemporary(Long momentId, int originalIndex, int newIndex, Long momentVersion) {
+		return locationRepository.updateLocationIndexToTemporary(momentId, originalIndex, newIndex, momentVersion);
 	}
 
 	@Transactional

--- a/src/main/java/com/genius/herewe/business/location/service/LocationService.java
+++ b/src/main/java/com/genius/herewe/business/location/service/LocationService.java
@@ -57,23 +57,19 @@ public class LocationService {
 	}
 
 	@Transactional
-	public int invertIndexesForDecrement(Long momentId, int lowerBound, int upperBound, Long momentVersion) {
-		return locationRepository.invertIndexesForDecrement(momentId, lowerBound, upperBound, momentVersion);
+	public boolean bulkDecreaseIndexes(Long momentId, int lowerBound, int upperBound, Long momentVersion) {
+		int invertedRows = locationRepository.invertIndexesForDecrement(momentId, lowerBound,
+																		upperBound, momentVersion);
+		int updatedRows = locationRepository.applyDecrementToInverted(momentId, -upperBound, momentVersion);
+		return !(invertedRows == 0 || updatedRows == 0);
 	}
 
 	@Transactional
-	public int applyDecrementToInverted(Long momentId, int lowerThreshold, Long momentVersion) {
-		return locationRepository.applyDecrementToInverted(momentId, lowerThreshold, momentVersion);
-	}
-
-	@Transactional
-	public int applyIncrementToInverted(Long momentId, int lowerThreshold, Long momentVersion) {
-		return locationRepository.applyIncrementToInverted(momentId, lowerThreshold, momentVersion);
-	}
-
-	@Transactional
-	public int invertIndexesForIncrement(Long momentId, int lowerBound, int upperBound, Long momentVersion) {
-		return locationRepository.invertIndexesForIncrement(momentId, lowerBound, upperBound, momentVersion);
+	public boolean bulkIncreaseIndexes(Long momentId, int lowerBound, int upperBound, Long momentVersion) {
+		int invertedRows = locationRepository.invertIndexesForIncrement(momentId, lowerBound,
+																		upperBound, momentVersion);
+		int updatedRows = locationRepository.applyIncrementToInverted(momentId, -upperBound, momentVersion);
+		return !(invertedRows == 0 || updatedRows == 0);
 	}
 
 	@Transactional

--- a/src/main/java/com/genius/herewe/business/location/service/LocationService.java
+++ b/src/main/java/com/genius/herewe/business/location/service/LocationService.java
@@ -82,8 +82,8 @@ public class LocationService {
 	}
 
 	@Transactional
-	public int updateLocationIndexToTemporary(Long momentId, int originalIndex, int newIndex, Long momentVersion) {
-		return locationRepository.updateLocationIndexToTemporary(momentId, originalIndex, newIndex, momentVersion);
+	public int repositionIndex(Long momentId, int originalIndex, int newIndex, Long momentVersion) {
+		return locationRepository.repositionIndex(momentId, originalIndex, newIndex, momentVersion);
 	}
 
 	@Transactional

--- a/src/main/java/com/genius/herewe/business/location/service/LocationService.java
+++ b/src/main/java/com/genius/herewe/business/location/service/LocationService.java
@@ -57,11 +57,6 @@ public class LocationService {
 	}
 
 	@Transactional
-	public int bulkDecreaseIndexes(Long momentId, int locationIndex, Long momentVersion) {
-		return locationRepository.bulkDecreaseIndexes(momentId, locationIndex, momentVersion);
-	}
-
-	@Transactional
 	public int invertIndexesForDecrement(Long momentId, int lowerBound, int upperBound, Long momentVersion) {
 		return locationRepository.invertIndexesForDecrement(momentId, lowerBound, upperBound, momentVersion);
 	}

--- a/src/main/java/com/genius/herewe/core/global/config/AsyncConfig.java
+++ b/src/main/java/com/genius/herewe/core/global/config/AsyncConfig.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-import com.genius.herewe.core.global.exception.AsyncExceptionHandler;
+import com.genius.herewe.core.global.exception.handler.AsyncExceptionHandler;
 
 @Configuration
 public class AsyncConfig implements AsyncConfigurer {

--- a/src/main/java/com/genius/herewe/core/global/exception/handler/AsyncExceptionHandler.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/handler/AsyncExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.genius.herewe.core.global.exception;
+package com.genius.herewe.core.global.exception.handler;
 
 import java.lang.reflect.Method;
 

--- a/src/main/java/com/genius/herewe/core/global/exception/handler/BusinessExceptionHandler.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/handler/BusinessExceptionHandler.java
@@ -1,9 +1,10 @@
-package com.genius.herewe.core.global.exception;
+package com.genius.herewe.core.global.exception.handler;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.genius.herewe.core.global.exception.BusinessException;
 import com.genius.herewe.core.global.response.ExceptionResponse;
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/genius/herewe/core/global/exception/handler/ConcurrencyExceptionHandler.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/handler/ConcurrencyExceptionHandler.java
@@ -1,0 +1,39 @@
+package com.genius.herewe.core.global.exception.handler;
+
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.UnexpectedRollbackException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import com.genius.herewe.core.global.exception.ErrorCode;
+import com.genius.herewe.core.global.response.ExceptionResponse;
+
+import jakarta.persistence.OptimisticLockException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ControllerAdvice
+public class ConcurrencyExceptionHandler {
+
+	@ExceptionHandler({
+		DataIntegrityViolationException.class,
+		PessimisticLockingFailureException.class,
+		CannotAcquireLockException.class,
+		UnexpectedRollbackException.class,
+		OptimisticLockException.class,
+		DataAccessException.class
+	})
+	@ResponseStatus(HttpStatus.CONFLICT)
+	public ResponseEntity<ExceptionResponse> handleConcurrencyException(Exception ex) {
+		log.warn("동시성 충돌 발생: {}", ex.getMessage());
+
+		return ResponseEntity.status(HttpStatus.CONFLICT)
+			.body(new ExceptionResponse(ErrorCode.CONCURRENT_MODIFICATION_EXCEPTION));
+	}
+}

--- a/src/main/java/com/genius/herewe/core/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/handler/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.genius.herewe.core.global.exception;
+package com.genius.herewe.core.global.exception.handler;
 
 import static com.genius.herewe.core.global.exception.ErrorCode.*;
 


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/63-update-place-order` -> `main`

</br>

### 🛠️ 변경 사항
> 모먼트 상세페이지에서 등록되어 있는 장소 리스트 중, 장소 하나의 순서를 변경하는 API를 개발합니다.

#### ✅ 작업 상세 내용
- [x] 장소 순서 변경 API 개발 `PATCH /api/location/{momentId}`
    - [x] request body에 수정하고자 하는 인덱스(originalIndex), 바꾸고자하는 인덱스(newIndex)를 받음
    - [x] 모먼트 참여 정보가 없을 때, request body에 담긴 값이 유효하지 않을 떄 예외 발생
    - [x] (moment_id, location_index) 복합 유니크 제약 조건으로 인해, 인덱스를 음수로 변경한 후, 다시 양수로 변경하는 로직 적용
- [x] exception 패키지 내에 handler 하위 패키지 생성 및 ExceptionHandler 클래스 위치 이동
- [x] 장소 삭제 요청 시 발생하는 이슈 해결
    - [x] 장소 삭제 API 요청 시, row lock으로 인해 발생하는 deadlock & unique 제약 조건 이슈 해결
    - [x] 벌크 연산 시 unique 제약 조건으로 인해 데이터가 정상적으로 갱신되지 않는 문제 발생
    - [x] 변경 대상 행들의 location_index를 모두 음수로 변환 후, 다시 양수로 변환하는 방법을 이용하여 이슈 해결
- [x] swagger 정보 입력 

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/eeb3cf72-9269-4a4d-9778-4563ad7193b1)

</br>

### 📚 연관된 이슈
#63

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
