### PR TITLE
[FIX] 장소 삭제/수정 시, 만남 장소에 대해서도 실행되는 버그 픽스

### DIFF
--- a/src/main/java/com/genius/herewe/business/location/facade/DefaultLocationFacade.java
+++ b/src/main/java/com/genius/herewe/business/location/facade/DefaultLocationFacade.java
@@ -164,7 +164,7 @@ public class DefaultLocationFacade implements LocationFacade {
 	}
 
 	private void validateIndex(int index, int lastIndex) {
-		if (1 > index || index > lastIndex) {
+		if (1 >= index || index > lastIndex) {
 			throw new BusinessException(INVALID_LOCATION_INDEX);
 		}
 	}

--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -48,7 +48,7 @@ public enum ErrorCode {
 
 	LOCATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 순서의 장소가 이미 추가되었습니다. 잠시 후 다시 시도해주세요."),
 	LOCATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "장소는 최대 100개까지 등록할 수 있습니다."),
-	INVALID_LOCATION_INDEX(HttpStatus.BAD_REQUEST, "유효하지 않은 위치 인덱스입니다."),
+	INVALID_LOCATION_INDEX(HttpStatus.BAD_REQUEST, "유효하지 않은 위치 인덱스입니다. 다시 확인해주세요."),
 
 	UNAUTHORIZED_ISSUE(HttpStatus.UNAUTHORIZED, "회원가입이 되어 있지 않은 사용자의 경우 JWT를 발급할 수 없습니다."),
 	JWT_NOT_VALID(HttpStatus.UNAUTHORIZED, "JWT가 유효하지 않습니다."),


### PR DESCRIPTION
- 장소 삭제/순서 수정 API 요청 시 만남 장소에 대해서도 처리되는 버그 픽스
- 요청 인덱스 유효성 확인 조건문에 인덱스의 값을 "1 미만"에서 "1 이하"로 변경
- 에러 코드 메세지 수정

### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`fix/97-meeting-place-exception` -> `main`

</br>

### 🛠️ 변경 사항
> 장소 순서 수정/삭제 API 요청 시, 만남 장소(index=1)에 대해서도 반영이 되는 버그
> 유효성을 확인하는 과정에서 요청 인덱스가 1인 경우, 즉 만남 장소인 경우 예외 발생 필요

#### ✅ 작업 상세 내용
- [x] 장소 삭제/순서 수정 API 요청 시 만남 장소에 대해서도 처리되는 버그 픽스
- [x] 요청 인덱스 유효성 확인 조건문에 인덱스의 값을 "1 미만"에서 "1 이하"로 변경
- [x] 에러 코드 메세지 수정

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/d80a1485-4b6a-47ec-9901-be489bcf59d3)


</br>

### 📚 연관된 이슈
#97

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
