### PR TITLE
[FEAT] 크루 초대 링크에 oauth 정보 추가

### DIFF
--- a/src/main/java/com/genius/herewe/business/invitation/facade/DefaultInvitationFacade.java
+++ b/src/main/java/com/genius/herewe/business/invitation/facade/DefaultInvitationFacade.java
@@ -20,6 +20,7 @@ import com.genius.herewe.business.invitation.dto.InvitationInfo;
 import com.genius.herewe.business.invitation.dto.InvitationRequest;
 import com.genius.herewe.business.invitation.service.InvitationService;
 import com.genius.herewe.core.global.exception.BusinessException;
+import com.genius.herewe.core.user.domain.ProviderInfo;
 import com.genius.herewe.core.user.domain.User;
 import com.genius.herewe.core.user.service.UserService;
 import com.genius.herewe.infra.mail.dto.MailRequest;
@@ -84,13 +85,14 @@ public class DefaultInvitationFacade implements InvitationFacade {
 				return invitationService.save(newInvitation);
 			});
 
+		String inviteUrl = getInviteUrl(invitation.getToken(), user.getProviderInfo());
 		MailRequest mailRequest = MailRequest.builder()
 			.receiverMail(user.getEmail())
 			.nickname(nickname)
 			.crewName(crew.getName())
 			.introduce(crew.getIntroduce())
 			.memberCount(crew.getParticipantCount())
-			.inviteUrl(BASE_URL + INVITE_URL + invitation.getToken())
+			.inviteUrl(inviteUrl)
 			.build();
 
 		mailManager.sendAsync(mailRequest).thenAccept(result -> {
@@ -101,6 +103,10 @@ public class DefaultInvitationFacade implements InvitationFacade {
 				log.info("Email sent successfully for invitation: {}", invitation.getToken());
 			}
 		});
+	}
+
+	private String getInviteUrl(String token, ProviderInfo provider) {
+		return String.format(BASE_URL + INVITE_URL, token, provider.name().toLowerCase());
 	}
 
 	@Transactional


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/101-add-oauth-to-invite-url` -> `main`

</br>

### 🛠️ 변경 사항
> 크루 초대 메일에 전달되는 크루 초대 링크에 oauth 정보를 포함합니다

#### ✅ 작업 상세 내용
- [x] 크루 초대 메일의 초대 링크에 oauth 정보 포함하도록 변경
    - [x] /invite?token={UUID token}&oauth={naver | kakao | google} 형태로 전달하도록 변경
- [x] git submodule 업데이트

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/c6f66cf3-d339-4ed8-815d-224787efe0e1)


</br>

### 📚 연관된 이슈
#101

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
