### PR TITLE
[INFRA] 배포서버 Redis 설정 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,12 @@ services:
     image: redis
     ports:
       - 6379:6379
+    command: redis-server --requirepass ${REDIS_ROOT_PASSWORD} --appendonly yes --save 900 1 --save 300 10 --save 60 10000 --replicaof no one --replica-read-only no
+    volumes:
+      - ./redis_data:/data
+    restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
+      test: [ "CMD", "redis-cli", "-a", "${REDIS_ROOT_PASSWORD}", "ping" ]
       interval: 5s
       timeout: 3s
       retries: 10


### PR DESCRIPTION
### PR 타입
□ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
☑ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`infra/104-apply-redis-rdb` -> `main`

</br>

### 🛠️ 변경 사항
> 1. 배포는 완료되었으나, redis 오류로 인해 소셜로그인이 되지 않는 버그 픽스
> 2. redis 환경 설정 변경 - 비밀번호/RDB 설정

#### ✅ 작업 상세 내용
- [x] `Caused by: io.lettuce.core.RedisReadOnlyException: READONLY You can't write against a read only replica.` 오류 해결을 위해 docker compose 파일 변경
- [x] redis 비밀번호 설정
- [x] redis RDB 설정
- [x] git submodule 업데이트

</br>

### 📚 연관된 이슈
#104 