### PR TITLE
[RELEASE] 1차 배포 - 버그 수정 사항 반영

### DIFF
--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -44,7 +44,7 @@ public enum ErrorCode {
 	MOMENT_DEADLINE_EXPIRED(HttpStatus.BAD_REQUEST, "모먼트 참여 마감일자가 지났습니다. 모먼트 참여/참여 취소는 마감일자 이전까지 가능합니다."),
 	MOMENT_CAPACITY_FULL(HttpStatus.BAD_REQUEST, "참여 인원이 최대 정원에 도달했습니다."),
 
-	MOMENT_PARTICIPATION_NOT_FOUND(HttpStatus.NOT_FOUND, "모먼트 참여 정보를 찾을 수 없습니다. 모먼트 참여자가 아닙니다."),
+	MOMENT_PARTICIPATION_NOT_FOUND(HttpStatus.FORBIDDEN, "모먼트 참여 정보를 찾을 수 없습니다. 모먼트 참여자가 아닙니다."),
 
 	LOCATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 순서의 장소가 이미 추가되었습니다. 잠시 후 다시 시도해주세요."),
 	LOCATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "장소는 최대 100개까지 등록할 수 있습니다."),

--- a/src/main/java/com/genius/herewe/core/global/exception/handler/BusinessExceptionHandler.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/handler/BusinessExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.genius.herewe.core.global.exception.handler;
 
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class BusinessExceptionHandler {
 
 	@ExceptionHandler(BusinessException.class)


### PR DESCRIPTION
## 1차 배포 - 버그 수정 사항 반영
#### 반영 브랜치
`main` -> `production`

</br>

## 🛠️ 개발 사항
### 1. 모먼트/장소의 데이터 변경 시 403 FORBIDDEN을 반환하도록 변경
- 모먼트/장소의 데이터 변경 시, 모먼트 참여자만 가능한 권한임
- 유효성 확인 과정에서 모먼트 참여자가 아닌 경우 403 FORBIDDEN을 반환하도록 변경 (기존에는 404 NOT FOUND 사용)

### 2. 커스텀 예외 핸들링이 적용되지 않는 버그 픽스
- BusinessException이 발생했음에도 불구하고, GlobalExceptionHandler가 동작해서 커스텀 예외가 전달되지 않는 버그 발생
- 스프링의 컴포넌트 스캔 과정에서, 클래스가 로드되는 순서가 달라져서 발생하는 문제로 판단
- 일관된 동작 보장을 위해 [@Order](https://github.com/Order) 어노테이션을 통해 우선순위 설정