### PR TITLE
[FEAT] 크루 탈퇴 API 개발

### DIFF
--- a/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
+++ b/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
@@ -43,7 +43,7 @@ public class CrewController implements CrewApi {
 
 	@GetMapping("/profile/{crewId}")
 	public SingleResponse<CrewProfileResponse> inquiryCrewProfile(@HereWeUser User user,
-		@PathVariable Long crewId) {
+																  @PathVariable Long crewId) {
 		CrewProfileResponse crewProfileResponse = crewFacade.inquiryCrewProfile(user.getId(), crewId);
 		return new SingleResponse<>(HttpStatus.OK, crewProfileResponse);
 	}
@@ -124,6 +124,13 @@ public class CrewController implements CrewApi {
 
 		crewFacade.expelCrew(user.getId(), new CrewExpelRequest(crewId, nickname));
 
+		return CommonResponse.ok();
+	}
+
+	@DeleteMapping("/{crewId}/members/me")
+	public CommonResponse quitCrew(@HereWeUser User user,
+								   @PathVariable Long crewId) {
+		crewFacade.quitCrew(user.getId(), crewId);
 		return CommonResponse.ok();
 	}
 }

--- a/src/main/java/com/genius/herewe/business/crew/facade/CrewFacade.java
+++ b/src/main/java/com/genius/herewe/business/crew/facade/CrewFacade.java
@@ -27,4 +27,6 @@ public interface CrewFacade {
 	void deleteCrew(Long crewId);
 
 	void expelCrew(Long userId, CrewExpelRequest expelRequest);
+
+	void quitCrew(Long userId, Long crewId);
 }

--- a/src/main/java/com/genius/herewe/business/crew/facade/DefaultCrewFacade.java
+++ b/src/main/java/com/genius/herewe/business/crew/facade/DefaultCrewFacade.java
@@ -125,4 +125,19 @@ public class DefaultCrewFacade implements CrewFacade {
 		crewMemberService.delete(crewMember);
 		crew.updateParticipantCount(-1);
 	}
+
+	@Override
+	@Transactional
+	public void quitCrew(Long userId, Long crewId) {
+		User user = userService.findById(userId);
+		Crew crew = crewService.findById(crewId);
+
+		CrewMember crewMember = crewMemberService.find(userId, crewId);
+		if (crewMember.getRole() == CrewRole.LEADER) {
+			throw new BusinessException(LEADER_CANNOT_EXPEL);
+		}
+
+		crewMemberService.delete(crewMember);
+		crew.updateParticipantCount(-1);
+	}
 }


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/110-quit-crew` -> `main`

</br>

### 🛠️ 변경 사항
> 크루 탈퇴 API를 개발합니다.
> 크루 내 역할이 LEADER인 경우에는 예외를 발생시킵니다.

#### ✅ 작업 상세 내용
- [x] 인증된 사용자가 특정 크루에 대해 탈퇴하는 API 개발
- [x] 크루 내 역할이 LEADER가 아닌 경우에만 가능
- [x] LEADER인 경우 LEADER_CANNOT_EXPEL 예외 발생

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/c00cc3d6-4cee-499b-bca3-0cfea941dc0f)


</br>

### 📚 연관된 이슈
#110

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
