### PR TITLE
[FEAT] 로그아웃 API 개발

### DIFF
--- a/src/main/java/com/genius/herewe/core/security/controller/AuthApi.java
+++ b/src/main/java/com/genius/herewe/core/security/controller/AuthApi.java
@@ -2,7 +2,9 @@ package com.genius.herewe.core.security.controller;
 
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
+import com.genius.herewe.core.global.response.CommonResponse;
 import com.genius.herewe.core.global.response.ExceptionResponse;
 import com.genius.herewe.core.global.response.SingleResponse;
 import com.genius.herewe.core.security.dto.AuthRequest;
@@ -111,4 +113,6 @@ public interface AuthApi {
 		)
 	})
 	SingleResponse<AuthResponse> reissueToken(HttpServletRequest request, HttpServletResponse response);
+
+	CommonResponse logout(HttpServletResponse response, @RequestParam String nickname);
 }

--- a/src/main/java/com/genius/herewe/core/security/controller/AuthApi.java
+++ b/src/main/java/com/genius/herewe/core/security/controller/AuthApi.java
@@ -114,5 +114,34 @@ public interface AuthApi {
 	})
 	SingleResponse<AuthResponse> reissueToken(HttpServletRequest request, HttpServletResponse response);
 
+	@Operation(summary = "로그아웃 API", description = "로그아웃 처리를 하는 API로서, redis & cookie에서 토큰 정보 삭제")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "로그아웃 처리 성공"
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = "해당 닉네임을 사용하고 있는 사용자를 찾지 못한 경우",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "해당 닉네임을 사용하고 있는 사용자를 찾지 못한 경우",
+						value = """
+							{
+								"resultCode": "404",
+								"code": "MEMBER_NOT_FOUND",
+								"message": "사용자를 찾을 수 없습니다."
+							}
+							"""
+					)
+				}
+			)
+		)
+	})
 	CommonResponse logout(HttpServletResponse response, @RequestParam String nickname);
+
+	@Operation(summary = "health check 전용 API", description = "서버가 제대로 동작하는지 확인하는 API")
+	String healthCheck();
 }

--- a/src/main/java/com/genius/herewe/core/security/controller/AuthController.java
+++ b/src/main/java/com/genius/herewe/core/security/controller/AuthController.java
@@ -5,8 +5,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.genius.herewe.core.global.response.CommonResponse;
 import com.genius.herewe.core.global.response.SingleResponse;
 import com.genius.herewe.core.security.dto.AuthRequest;
 import com.genius.herewe.core.security.dto.AuthResponse;
@@ -37,6 +39,12 @@ public class AuthController implements AuthApi {
 		Long userId = authFacade.reissueToken(request, response);
 		AuthResponse authResponse = userFacade.getAuthInfo(userId);
 		return new SingleResponse<>(HttpStatus.OK, authResponse);
+	}
+
+	@PostMapping("/auth/logout")
+	public CommonResponse logout(HttpServletResponse response, @RequestParam String nickname) {
+		authFacade.logout(response, nickname);
+		return CommonResponse.ok();
 	}
 
 	@GetMapping("/auth/health-check")

--- a/src/main/java/com/genius/herewe/core/security/facade/AuthFacade.java
+++ b/src/main/java/com/genius/herewe/core/security/facade/AuthFacade.java
@@ -9,4 +9,6 @@ public interface AuthFacade {
 	Long authorize(HttpServletResponse response, AuthRequest authRequest);
 
 	Long reissueToken(HttpServletRequest request, HttpServletResponse response);
+
+	void logout(HttpServletResponse response, String nickname);
 }

--- a/src/main/java/com/genius/herewe/core/security/facade/DefaultAuthFacade.java
+++ b/src/main/java/com/genius/herewe/core/security/facade/DefaultAuthFacade.java
@@ -1,6 +1,7 @@
 package com.genius.herewe.core.security.facade;
 
 import static com.genius.herewe.core.global.exception.ErrorCode.*;
+import static com.genius.herewe.core.security.constants.JwtRule.*;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,9 +10,11 @@ import com.genius.herewe.core.global.exception.BusinessException;
 import com.genius.herewe.core.security.dto.AuthRequest;
 import com.genius.herewe.core.security.service.JwtManager;
 import com.genius.herewe.core.security.service.token.AuthTokenService;
+import com.genius.herewe.core.security.service.token.RefreshTokenService;
 import com.genius.herewe.core.user.domain.User;
 import com.genius.herewe.core.user.service.UserService;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +26,7 @@ public class DefaultAuthFacade implements AuthFacade {
 	private final JwtManager jwtManager;
 	private final UserService userService;
 	private final AuthTokenService authTokenService;
+	private final RefreshTokenService refreshTokenService;
 
 	@Transactional
 	public Long authorize(HttpServletResponse response, AuthRequest authRequest) {
@@ -54,5 +58,18 @@ public class DefaultAuthFacade implements AuthFacade {
 		jwtManager.setReissuedHeader(response);
 
 		return user.getId();
+	}
+
+	@Override
+	public void logout(HttpServletResponse response, String nickname) {
+		User user = userService.findByNickname(nickname)
+			.orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
+
+		Cookie cookie = new Cookie(REFRESH_PREFIX.getValue(), null);
+		cookie.setMaxAge(0);
+		cookie.setPath("/");
+		response.addCookie(cookie);
+
+		refreshTokenService.delete(user.getId());
 	}
 }


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/115-logout` -> `main`

</br>

### 🛠️ 변경 사항
> 로그아웃 API를 개발합니다.

#### ✅ 작업 상세 내용
- [x] 로그아웃 API 개발 `POST /api/logout?nickname={nickname}`
- [x] redis에서 refresh-token 정보 삭제 및 Cookie에서 refresh token 삭제
- [x] swagger docs 작성

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/22d8bd7a-f816-4f86-a23d-0ecbfddc961b)


</br>

### 📚 연관된 이슈
#115

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
