### PR TITLE
[FEAT] 크루리더 양도하기 API 개발

### DIFF
--- a/src/main/java/com/genius/herewe/business/crew/controller/CrewApi.java
+++ b/src/main/java/com/genius/herewe/business/crew/controller/CrewApi.java
@@ -419,7 +419,7 @@ public interface CrewApi {
 						{
 							"resultCode": 400,
 							"code": "LEADER_CANNOT_EXPEL",
-							"message"; "CREW LEADER는 CREW에서 탈퇴할 수 없습니다."
+							"message": "CREW LEADER는 CREW에서 탈퇴할 수 없습니다."
 						}
 						"""
 				)
@@ -436,7 +436,7 @@ public interface CrewApi {
 						{
 							"resultCode": 403,
 							"code": "LEADER_PERMISSION_DENIED",
-							"message"; "CREW LEADER의 권한이 필요합니다."
+							"message": "CREW LEADER의 권한이 필요합니다."
 						}
 						"""
 				)
@@ -458,7 +458,7 @@ public interface CrewApi {
 							{
 								"resultCode": 404,
 								"code": "MEMBER_NOT_FOUND",
-								"message"; "사용자를 찾을 수 없습니다."
+								"message": "사용자를 찾을 수 없습니다."
 							}
 							"""
 					),
@@ -468,7 +468,7 @@ public interface CrewApi {
 							{
 								"resultCode": 404,
 								"code": "CREW_NOT_FOUND",
-								"message"; "해당 CREW를 찾을 수 없습니다."
+								"message": "해당 CREW를 찾을 수 없습니다."
 							}
 							"""
 					),
@@ -478,7 +478,7 @@ public interface CrewApi {
 							{
 								"resultCode": 404,
 								"code": "MEMBER_NOT_FOUND",
-								"message"; "사용자를 찾을 수 없습니다."
+								"message": "사용자를 찾을 수 없습니다."
 							}
 							"""
 					)
@@ -490,6 +490,64 @@ public interface CrewApi {
 		@HereWeUser User user, @PathVariable Long crewId,
 		@RequestParam(name = "nickname") String nickname);
 
+	@Operation(summary = "크루 리더 양도 API", description = "크루 멤버에 대하여 크루 리더를 양도하는 API")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "크루 리더 양도 성공"
+		),
+		@ApiResponse(
+			responseCode = "403",
+			description = """
+				1. 요청자가 크루 리더가 아닌 경우
+				2. 대상자가 크루 멤버가 아닌 경우
+				""",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "1. 요청자가 크루 리더가 아닌 경우",
+						value = """
+							{
+								"resultCode": 403,
+								"code": "LEADER_PERMISSION_DENIED",
+								"message": "CREW LEADER의 권한이 필요합니다."
+							}
+							"""
+					),
+					@ExampleObject(
+						name = "2. 대상자가 크루 멤버가 아닌 경우",
+						value = """
+							{
+								"resultCode": 403,
+								"code": "CREW_MEMBERSHIP_REQUIRED",
+								"message": "크루 멤버에게만 허용된 작업입니다. 크루에 참여 후 재시도해주세요."
+							}
+							"""
+					)
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = "닉네임을 통해 대상자를 찾을 수 없는 경우",
+			content = @Content(
+				schema = @Schema(implementation = ExceptionResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "닉네임을 통해 대상자를 찾을 수 없는 경우",
+						value = """
+							{
+								"resultCode": 404,
+								"code": "MEMBER_NOT_FOUND",
+								"message": "사용자를 찾을 수 없습니다."
+							}
+							"""
+					)
+				}
+			)
+		)
+	})
 	CommonResponse handOverLeader(@HereWeUser User user, @PathVariable Long crewId,
 								  @RequestBody @Valid CrewLeaderTransferRequest transferRequest);
 }

--- a/src/main/java/com/genius/herewe/business/crew/controller/CrewApi.java
+++ b/src/main/java/com/genius/herewe/business/crew/controller/CrewApi.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.genius.herewe.business.crew.dto.CrewCreateRequest;
+import com.genius.herewe.business.crew.dto.CrewLeaderTransferRequest;
 import com.genius.herewe.business.crew.dto.CrewMemberResponse;
 import com.genius.herewe.business.crew.dto.CrewModifyRequest;
 import com.genius.herewe.business.crew.dto.CrewPreviewResponse;
@@ -488,5 +489,8 @@ public interface CrewApi {
 	CommonResponse expelCrew(
 		@HereWeUser User user, @PathVariable Long crewId,
 		@RequestParam(name = "nickname") String nickname);
+
+	CommonResponse handOverLeader(@HereWeUser User user, @PathVariable Long crewId,
+								  @RequestBody @Valid CrewLeaderTransferRequest transferRequest);
 }
 

--- a/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
+++ b/src/main/java/com/genius/herewe/business/crew/controller/CrewController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.genius.herewe.business.crew.dto.CrewCreateRequest;
 import com.genius.herewe.business.crew.dto.CrewExpelRequest;
 import com.genius.herewe.business.crew.dto.CrewIdResponse;
+import com.genius.herewe.business.crew.dto.CrewLeaderTransferRequest;
 import com.genius.herewe.business.crew.dto.CrewMemberResponse;
 import com.genius.herewe.business.crew.dto.CrewModifyRequest;
 import com.genius.herewe.business.crew.dto.CrewPreviewResponse;
@@ -131,6 +132,14 @@ public class CrewController implements CrewApi {
 	public CommonResponse quitCrew(@HereWeUser User user,
 								   @PathVariable Long crewId) {
 		crewFacade.quitCrew(user.getId(), crewId);
+		return CommonResponse.ok();
+	}
+
+	@PatchMapping("/{crewId}/members/leader")
+	public CommonResponse handOverLeader(@HereWeUser User user, @PathVariable Long crewId,
+										 @RequestBody @Valid CrewLeaderTransferRequest transferRequest) {
+
+		crewFacade.handoverLeader(crewId, user.getId(), transferRequest.nickname());
 		return CommonResponse.ok();
 	}
 }

--- a/src/main/java/com/genius/herewe/business/crew/domain/CrewMember.java
+++ b/src/main/java/com/genius/herewe/business/crew/domain/CrewMember.java
@@ -51,6 +51,11 @@ public class CrewMember {
 		return new CrewMember(role, LocalDate.now());
 	}
 
+	//== 비지니스 로직 ==//
+	public void updateRole(CrewRole crewRole) {
+		this.role = crewRole;
+	}
+
 	//== 연관관계 편의 메서드 ==//
 	public void joinCrew(User user, Crew crew) {
 		this.user = user;

--- a/src/main/java/com/genius/herewe/business/crew/dto/CrewLeaderTransferRequest.java
+++ b/src/main/java/com/genius/herewe/business/crew/dto/CrewLeaderTransferRequest.java
@@ -1,0 +1,9 @@
+package com.genius.herewe.business.crew.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CrewLeaderTransferRequest(
+	@NotBlank
+	String nickname
+) {
+}

--- a/src/main/java/com/genius/herewe/business/crew/facade/CrewFacade.java
+++ b/src/main/java/com/genius/herewe/business/crew/facade/CrewFacade.java
@@ -29,4 +29,6 @@ public interface CrewFacade {
 	void expelCrew(Long userId, CrewExpelRequest expelRequest);
 
 	void quitCrew(Long userId, Long crewId);
+
+	void handoverLeader(Long crewId, Long userId, String targetNickname);
 }

--- a/src/main/java/com/genius/herewe/business/crew/facade/DefaultCrewFacade.java
+++ b/src/main/java/com/genius/herewe/business/crew/facade/DefaultCrewFacade.java
@@ -140,4 +140,22 @@ public class DefaultCrewFacade implements CrewFacade {
 		crewMemberService.delete(crewMember);
 		crew.updateParticipantCount(-1);
 	}
+
+	@Override
+	@Transactional
+	public void handoverLeader(Long crewId, Long userId, String targetNickname) {
+		User leader = userService.findById(userId);
+		User newLeader = userService.findByNickname(targetNickname)
+			.orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
+
+		CrewMember originLeaderJoinInfo = crewMemberService.find(leader.getId(), crewId);
+		if (originLeaderJoinInfo.getRole() != CrewRole.LEADER) {
+			throw new BusinessException(LEADER_PERMISSION_DENIED);
+		}
+		CrewMember newLeaderJoinInfo = crewMemberService.findOptional(newLeader.getId(), crewId)
+			.orElseThrow(() -> new BusinessException(CREW_MEMBERSHIP_REQUIRED));
+
+		originLeaderJoinInfo.updateRole(CrewRole.MEMBER);
+		newLeaderJoinInfo.updateRole(CrewRole.LEADER);
+	}
 }

--- a/src/main/java/com/genius/herewe/business/crew/facade/DefaultCrewFacade.java
+++ b/src/main/java/com/genius/herewe/business/crew/facade/DefaultCrewFacade.java
@@ -2,6 +2,8 @@ package com.genius.herewe.business.crew.facade;
 
 import static com.genius.herewe.core.global.exception.ErrorCode.*;
 
+import java.util.Objects;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -151,6 +153,9 @@ public class DefaultCrewFacade implements CrewFacade {
 		CrewMember originLeaderJoinInfo = crewMemberService.find(leader.getId(), crewId);
 		if (originLeaderJoinInfo.getRole() != CrewRole.LEADER) {
 			throw new BusinessException(LEADER_PERMISSION_DENIED);
+		}
+		if (Objects.equals(leader.getId(), newLeader.getId())) {
+			throw new BusinessException(LEADER_ALREADY_ASSIGNED);
 		}
 		CrewMember newLeaderJoinInfo = crewMemberService.findOptional(newLeader.getId(), crewId)
 			.orElseThrow(() -> new BusinessException(CREW_MEMBERSHIP_REQUIRED));

--- a/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
+++ b/src/main/java/com/genius/herewe/core/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
 	CREW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 CREW를 찾을 수 없습니다."),
 	LEADER_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "CREW LEADER의 권한이 필요합니다."),
 	LEADER_CANNOT_EXPEL(HttpStatus.BAD_REQUEST, "CREW LEADER는 CREW에서 탈퇴할 수 없습니다."),
+	LEADER_ALREADY_ASSIGNED(HttpStatus.BAD_REQUEST, "이미 LEADER인 사용자에 대해서는 LEADER 양도가 불가능합니다."),
 
 	CREW_JOIN_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 크루에 대한 참여 정보가 없습니다."),
 	ALREADY_JOINED_CREW(HttpStatus.BAD_REQUEST, "이미 참여한 크루입니다."),


### PR DESCRIPTION
### PR 타입
☑ 기능 추가
□ 기능 삭제
□ 리팩터링
□ 버그 리포트
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/116-hand-over-crew-leader` -> `main`

</br>

### 🛠️ 변경 사항
> 본인이 크루 리더인 크루에서, 다른 크루원에세 크루 리더 역할을 양도하는 API를 개발합니다.

#### ✅ 작업 상세 내용
- [x] 크루리더 양도 API 개발 `PATCH /api/crew/{crewId}/members/leader`
- [x] 요청자가 크루리더가 아닌 경우, 대상자가 크루 참여자가 아닌 경우, 대상자의 닉네임을 통해 사용자를 찾을 수 없는 경우, 리더가 본인에 대해 리더 양도를 요청한 경우 예외 발생
- [x] swagger docs 업데이트

</br>

### 🧪 테스트 결과
![image](https://github.com/user-attachments/assets/2c3522c0-539e-4ea4-8b42-bb94e29f6ee5)


</br>

### 📚 연관된 이슈
ex) #이슈번호, #이슈번호

</br>

### 🤔 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
